### PR TITLE
kinfra-parent設定のサポートを追加

### DIFF
--- a/action/src/main/kotlin/net/kigawa/kinfra/action/config/ConfigRepository.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/config/ConfigRepository.kt
@@ -2,6 +2,7 @@ package net.kigawa.kinfra.action.config
 
 import net.kigawa.kinfra.model.conf.GlobalConfig
 import net.kigawa.kinfra.model.conf.KinfraConfig
+import net.kigawa.kinfra.model.conf.KinfraParentConfig
 
 interface ConfigRepository {
     fun loadGlobalConfig(): GlobalConfig
@@ -11,4 +12,8 @@ interface ConfigRepository {
     fun loadKinfraConfig(filePath: String): KinfraConfig?
     fun saveKinfraConfig(config: KinfraConfig, filePath: String)
     fun kinfraConfigExists(filePath: String): Boolean
+
+    fun loadKinfraParentConfig(filePath: String): KinfraParentConfig?
+    fun saveKinfraParentConfig(config: KinfraParentConfig, filePath: String)
+    fun kinfraParentConfigExists(filePath: String): Boolean
 }

--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/ConfigRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/ConfigRepositoryImpl.kt
@@ -5,6 +5,7 @@ import net.kigawa.kinfra.action.config.ConfigRepository
 import net.kigawa.kinfra.model.conf.FilePaths
 import net.kigawa.kinfra.model.conf.GlobalConfig
 import net.kigawa.kinfra.model.conf.KinfraConfig
+import net.kigawa.kinfra.model.conf.KinfraParentConfig
 import java.io.File
 
 class ConfigRepositoryImpl(
@@ -73,6 +74,29 @@ class ConfigRepositoryImpl(
     }
 
     override fun kinfraConfigExists(filePath: String): Boolean {
+        return resolveFilePath(filePath).exists()
+    }
+
+    override fun loadKinfraParentConfig(filePath: String): KinfraParentConfig? {
+        val file = resolveFilePath(filePath)
+        if (!file.exists()) {
+            return null
+        }
+
+        val yamlContent = file.readText()
+        return Yaml.default.decodeFromString(KinfraParentConfigScheme.serializer(), yamlContent)
+    }
+
+    override fun saveKinfraParentConfig(config: KinfraParentConfig, filePath: String) {
+        val file = resolveFilePath(filePath)
+        val yamlContent = Yaml.default.encodeToString(
+            KinfraParentConfigScheme.serializer(),
+            KinfraParentConfigScheme.from(config)
+        )
+        file.writeText(yamlContent)
+    }
+
+    override fun kinfraParentConfigExists(filePath: String): Boolean {
         return resolveFilePath(filePath).exists()
     }
 

--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraParentConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraParentConfigScheme.kt
@@ -1,0 +1,28 @@
+package net.kigawa.kinfra.infrastructure.config
+
+import kotlinx.serialization.Serializable
+import net.kigawa.kinfra.model.conf.*
+
+/**
+ * Serializable implementation of KinfraParentConfig
+ */
+@Serializable
+data class KinfraParentConfigScheme(
+    override val projectName: String = "",
+    override val description: String? = null,
+    override val terraform: TerraformSettingsScheme? = null,
+    override val subProjects: List<String> = emptyList(),
+    override val bitwarden: BitwardenSettingsScheme? = null,
+    override val update: UpdateSettingsScheme? = null
+) : KinfraParentConfig {
+    companion object {
+        fun from(config: KinfraParentConfig): KinfraParentConfigScheme {
+            if (config is KinfraParentConfigScheme) {
+                return config
+            }
+            throw IllegalArgumentException(
+                "KinfraParentConfig cannot be converted to a ${KinfraParentConfigScheme::class.simpleName}"
+            )
+        }
+    }
+}

--- a/kinfra-parent.yaml.sample
+++ b/kinfra-parent.yaml.sample
@@ -1,0 +1,29 @@
+# Kinfra Parent Project Configuration
+# This file defines common settings for multi-project setups
+
+# Project name
+projectName: "my-infrastructure"
+
+# Optional project description
+description: "Parent project for managing multiple infrastructure components"
+
+# Common Terraform settings applied to all sub-projects
+terraform:
+  version: "1.5.0"
+  workingDirectory: "terraform"
+
+# List of sub-project paths or identifiers
+subProjects:
+  - "project-a"
+  - "project-b"
+  - "project-c"
+
+# Common Bitwarden settings
+bitwarden:
+  projectId: "your-bitwarden-project-id"
+
+# Update settings for auto-update functionality
+update:
+  autoUpdate: true
+  checkInterval: 86400000  # 24 hours in milliseconds
+  githubRepo: "kigawa-net/kinfra"

--- a/model/src/main/kotlin/net/kigawa/kinfra/model/conf/FilePaths.kt
+++ b/model/src/main/kotlin/net/kigawa/kinfra/model/conf/FilePaths.kt
@@ -29,6 +29,7 @@ class FilePaths(
      */
      val projectConfigFileName = "project.yaml"
      val kinfraConfigFileName = "kinfra.yaml"
+     val kinfraParentConfigFileName = "kinfra-parent.yaml"
 
     /**
      * Bitwarden関連ファイル

--- a/model/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraParentConfig.kt
+++ b/model/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraParentConfig.kt
@@ -1,0 +1,37 @@
+package net.kigawa.kinfra.model.conf
+
+/**
+ * Kinfra parent project configuration
+ * Used for managing common settings across multiple sub-projects
+ */
+interface KinfraParentConfig {
+    /**
+     * Parent project name
+     */
+    val projectName: String
+
+    /**
+     * Parent project description
+     */
+    val description: String?
+
+    /**
+     * Common Terraform settings for all sub-projects
+     */
+    val terraform: TerraformSettings?
+
+    /**
+     * List of sub-project paths or identifiers
+     */
+    val subProjects: List<String>
+
+    /**
+     * Common Bitwarden settings
+     */
+    val bitwarden: BitwardenSettings?
+
+    /**
+     * Update settings for the parent project
+     */
+    val update: UpdateSettings?
+}


### PR DESCRIPTION
## 概要
- 複数のサブプロジェクトで共通設定を管理するための親プロジェクト設定機能を追加
- KinfraParentConfigインターフェースとKinfraParentConfigScheme実装を追加
- ConfigRepositoryに親設定の操作メソッドを追加
- サンプル設定ファイルを含む

## 変更内容
- **model**: 親プロジェクト設定用の`KinfraParentConfig`インターフェースを追加
- **model**: `FilePaths`に`kinfraParentConfigFileName`定数を追加
- **infrastructure**: kotlinx-serializationサポート付きの`KinfraParentConfigScheme`を追加
- **action**: `ConfigRepository`インターフェースに親設定メソッドを追加:
  - `loadKinfraParentConfig()`
  - `saveKinfraParentConfig()`
  - `kinfraParentConfigExists()`
- **infrastructure**: `ConfigRepositoryImpl`に親設定メソッドを実装
- `kinfra-parent.yaml.sample`サンプルファイルを追加

## 設定構造
親設定には以下が含まれます:
- プロジェクト名と説明
- 全サブプロジェクト共通のTerraform設定
- サブプロジェクト識別子のリスト
- 共有Bitwarden設定
- 更新設定

## テスト計画
- [x] ビルド成功
- [x] 設定インターフェースが適切に定義されている
- [x] シリアライズ/デシリアライズが正しく動作する
- [ ] サンプル設定を使った手動テスト
- [ ] サブプロジェクト読み込みとの統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)