### PR TITLE
config編集コマンドを追加

### DIFF
--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ConfigEditAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ConfigEditAction.kt
@@ -1,0 +1,146 @@
+package net.kigawa.kinfra.action.actions
+
+import net.kigawa.kinfra.model.Action
+import net.kigawa.kinfra.model.LoginRepo
+import net.kigawa.kinfra.model.conf.FilePaths
+import net.kigawa.kinfra.model.util.AnsiColors
+import java.io.File
+
+class ConfigEditAction(
+    private val loginRepo: LoginRepo,
+    private val filePaths: FilePaths
+) : Action {
+
+    override fun execute(args: Array<String>): Int {
+        val isParentConfig = args.contains("--parent") || args.contains("-p")
+
+        return if (isParentConfig) {
+            editParentConfig()
+        } else {
+            editProjectConfig()
+        }
+    }
+
+    private fun editProjectConfig(): Int {
+        val configPath = try {
+            loginRepo.kinfraConfigPath()
+        } catch (e: IllegalStateException) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Login configuration not found")
+            println("${AnsiColors.BLUE}Hint:${AnsiColors.RESET} Run 'kinfra login <github-repo>' first")
+            return 1
+        }
+
+        val configFile = configPath.toFile()
+
+        // Create sample config if it doesn't exist
+        if (!configFile.exists()) {
+            println("${AnsiColors.YELLOW}Configuration file not found. Creating from sample...${AnsiColors.RESET}")
+            configFile.parentFile?.mkdirs()
+
+            val sampleContent = """
+                # Kinfra Project Configuration
+
+                rootProject:
+                  projectId: "my-project"
+                  description: "My infrastructure project"
+                  terraform:
+                    version: "1.5.0"
+                    workingDirectory: "terraform"
+
+                subProjects: []
+
+                # Optional Bitwarden settings
+                # bitwarden:
+                #   projectId: "your-bitwarden-project-id"
+
+                # Optional update settings
+                # update:
+                #   autoUpdate: true
+                #   checkInterval: 86400000
+                #   githubRepo: "kigawa-net/kinfra"
+            """.trimIndent()
+
+            configFile.writeText(sampleContent)
+            println("${AnsiColors.GREEN}✓${AnsiColors.RESET} Created sample configuration at ${configFile.absolutePath}")
+        }
+
+        return openInEditor(configFile)
+    }
+
+    private fun editParentConfig(): Int {
+        val currentDir = File(System.getProperty("user.dir"))
+        val configFile = File(currentDir, filePaths.kinfraParentConfigFileName)
+
+        // Create sample config if it doesn't exist
+        if (!configFile.exists()) {
+            println("${AnsiColors.YELLOW}Parent configuration file not found. Creating from sample...${AnsiColors.RESET}")
+
+            val sampleContent = """
+                # Kinfra Parent Project Configuration
+
+                projectName: "my-infrastructure"
+                description: "Parent project for managing multiple infrastructure components"
+
+                # Common Terraform settings for all sub-projects
+                terraform:
+                  version: "1.5.0"
+                  workingDirectory: "terraform"
+
+                # List of sub-project paths or identifiers
+                subProjects:
+                  - "project-a"
+                  - "project-b"
+                  - "project-c"
+
+                # Optional Bitwarden settings
+                # bitwarden:
+                #   projectId: "your-bitwarden-project-id"
+
+                # Optional update settings
+                # update:
+                #   autoUpdate: true
+                #   checkInterval: 86400000
+                #   githubRepo: "kigawa-net/kinfra"
+            """.trimIndent()
+
+            configFile.writeText(sampleContent)
+            println("${AnsiColors.GREEN}✓${AnsiColors.RESET} Created sample parent configuration at ${configFile.absolutePath}")
+        }
+
+        return openInEditor(configFile)
+    }
+
+    private fun openInEditor(file: File): Int {
+        val editor = System.getenv("EDITOR") ?: "vim"
+
+        println("${AnsiColors.BLUE}Opening configuration file in $editor...${AnsiColors.RESET}")
+        println("${AnsiColors.CYAN}File:${AnsiColors.RESET} ${file.absolutePath}")
+        println()
+
+        return try {
+            val process = ProcessBuilder(editor, file.absolutePath)
+                .inheritIO()
+                .start()
+
+            val exitCode = process.waitFor()
+
+            println()
+            if (exitCode == 0) {
+                println("${AnsiColors.GREEN}✓${AnsiColors.RESET} Configuration file edited successfully")
+                0
+            } else {
+                println("${AnsiColors.YELLOW}Editor exited with code $exitCode${AnsiColors.RESET}")
+                exitCode
+            }
+        } catch (e: Exception) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Failed to open editor: ${e.message}")
+            println("${AnsiColors.BLUE}Hint:${AnsiColors.RESET} Set the EDITOR environment variable to your preferred editor")
+            println("  Example: export EDITOR=nano")
+            1
+        }
+    }
+
+    override fun getDescription(): String {
+        return "Edit kinfra configuration files (use --parent for parent config)"
+    }
+}

--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/TerraformRunner.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/TerraformRunner.kt
@@ -86,7 +86,7 @@ class TerraformRunner(
             exitProcess(1)
         }
 
-        // Skip Terraform check for help, login, hello, setup-r2, self-update and push actions
+        // Skip Terraform check for help, login, hello, setup-r2, self-update, push and config actions
         val skipTerraformCheck = actionName == ActionType.HELP.actionName
             || actionName == ActionType.LOGIN.actionName
             || actionName == ActionType.HELLO.actionName
@@ -94,6 +94,7 @@ class TerraformRunner(
             || actionName == ActionType.SETUP_R2_SDK.actionName
             || actionName == ActionType.SELF_UPDATE.actionName
             || actionName == ActionType.PUSH.actionName
+            || actionName == ActionType.CONFIG_EDIT.actionName
         if (!skipTerraformCheck && !isTerraformInstalled()) {
             logger.error("Terraform is not installed")
             println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform is not installed or not found in PATH.")

--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/di/AppModule.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/di/AppModule.kt
@@ -4,6 +4,7 @@ import net.kigawa.kinfra.TerraformRunner
 import net.kigawa.kinfra.action.GitHelper
 import net.kigawa.kinfra.action.TerraformService
 import net.kigawa.kinfra.action.actions.ApplyAction
+import net.kigawa.kinfra.action.actions.ConfigEditAction
 import net.kigawa.kinfra.action.actions.DeployAction
 import net.kigawa.kinfra.action.actions.DeployActionWithSDK
 import net.kigawa.kinfra.action.actions.DestroyAction
@@ -132,6 +133,7 @@ val appModule = module {
     single<Action>(named(ActionType.DESTROY.actionName)) { DestroyAction(get(), get()) }
     single<Action>(named(ActionType.DEPLOY.actionName)) { DeployAction(get(), get()) }
     single<Action>(named(ActionType.PUSH.actionName)) { PushAction(get()) }
+    single<Action>(named(ActionType.CONFIG_EDIT.actionName)) { ConfigEditAction(get(), get()) }
     single<Action>(named(ActionType.SELF_UPDATE.actionName)) { SelfUpdateAction(get(), get(), get(), get(), get(), get()) }
 
     // SDK-based actions (only if BWS_ACCESS_TOKEN is available)

--- a/model/src/main/kotlin/net/kigawa/kinfra/model/ActionType.kt
+++ b/model/src/main/kotlin/net/kigawa/kinfra/model/ActionType.kt
@@ -16,7 +16,8 @@ enum class ActionType(val actionName: String) {
     HELP("help"),
     HELLO("hello"),
     SELF_UPDATE("self-update"),
-    PUSH("push");
+    PUSH("push"),
+    CONFIG_EDIT("config");
 
     companion object {
         fun fromString(name: String): ActionType? {


### PR DESCRIPTION
## 概要
- kinfraの設定ファイルをエディタで編集するための`config`コマンドを追加
- プロジェクト設定（kinfra.yaml）と親設定（kinfra-parent.yaml）の両方に対応
- 設定ファイルが存在しない場合は自動的にサンプルを作成

## 変更内容
- **model**: `ActionType` enumに`CONFIG_EDIT("config")`を追加
- **action**: `ConfigEditAction`を実装
  - デフォルトでkinfra.yamlを編集
  - `--parent`または`-p`フラグでkinfra-parent.yamlを編集
  - 設定ファイルが存在しない場合はサンプルから自動作成
  - EDITOR環境変数を使用（デフォルト: vim）
- **app-cli**: AppModuleにConfigEditActionを登録
- **app-cli**: TerraformRunnerのskipTerraformCheckにCONFIG_EDITを追加

## 使用方法
```bash
# プロジェクト設定を編集
kinfra config

# 親プロジェクト設定を編集
kinfra config --parent

# エディタを指定
export EDITOR=nano
kinfra config
```

## 機能
- ✅ プロジェクト設定（kinfra.yaml）の編集
- ✅ 親設定（kinfra-parent.yaml）の編集
- ✅ 設定ファイルの自動作成（サンプルテンプレート付き）
- ✅ EDITOR環境変数のサポート
- ✅ Terraformチェックのスキップ

## テスト計画
- [x] ビルド成功
- [x] ActionTypeに正しく登録
- [x] ConfigEditActionが正しく実装されている
- [ ] 手動テスト: kinfra config
- [ ] 手動テスト: kinfra config --parent
- [ ] 手動テスト: EDITOR環境変数の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)