### PR TITLE
config -p editコマンドの解析を修正

### DIFF
--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/service/CommandInterpreter.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/service/CommandInterpreter.kt
@@ -48,10 +48,13 @@ class CommandInterpreter: KoinComponent {
 
         // Handle config subcommands
         if (actionName == ActionType.CONFIG.actionName && actionArgs.isNotEmpty()) {
-            when (actionArgs[0]) {
+            // Find the subcommand (skip flags like -p, --parent)
+            val subCommand = actionArgs.find { !it.startsWith("-") }
+            when (subCommand) {
                 "edit" -> {
                     actionName = ActionType.CONFIG_EDIT.actionName
-                    actionArgs = actionArgs.drop(1)
+                    // Remove the subcommand but keep flags
+                    actionArgs = actionArgs.filter { it != "edit" }
                     logger.info("Mapped 'config edit' to config-edit action")
                 }
 


### PR DESCRIPTION
## 概要
`kinfra config -p edit`コマンドが正しく動作していなかった問題を修正。

## 問題
- `config -p edit`コマンドが`CONFIG_EDIT`アクションに正しくマッピングされていなかった
- フラグ（-p）とサブコマンド（edit）の順序を正しく解析できていなかった

## 修正内容
- CommandInterpreterのconfigサブコマンド解析ロジックを改善
- フラグをスキップしてサブコマンドを正しく検出するように変更
- `config -p edit`が正しく`CONFIG_EDIT`アクションにマッピングされるように修正

## テスト結果
- ✅ `config -p edit` - 親設定ファイルをエディタで開く
- ✅ `config edit` - プロジェクト設定ファイルをエディタで開く  
- ✅ `config add-subproject test-project` - サブプロジェクトを追加

## 技術詳細
- `actionArgs.find { !it.startsWith("-") }`でフラグをスキップしてサブコマンドを検出
- サブコマンドを除去した引数リストをアクションに渡す
- 既存の`add-subproject`コマンドも引き続き正常に動作