### PR TITLE
fix: ProjectInfoSchemeの後方互換性を追加

### DIFF
--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
@@ -5,17 +5,22 @@ import net.kigawa.kinfra.model.conf.*
 
 @Serializable
 data class ProjectInfoScheme(
-    override val projectId: String = "",
+    private val projectIdField: String? = null,
     override val description: String? = null,
-    override val terraform: TerraformSettingsScheme? = null
+    override val terraform: TerraformSettingsScheme? = null,
+    // Backward compatibility for old 'name' property
+    private val name: String? = null
 ) : ProjectInfo {
+
+    override val projectId: String
+        get() = projectIdField ?: name ?: ""
     companion object {
         fun from(projectInfo: ProjectInfo): ProjectInfoScheme {
             if (projectInfo is ProjectInfoScheme) {
                 return projectInfo
             }
             return ProjectInfoScheme(
-                projectId = projectInfo.projectId,
+                projectIdField = projectInfo.projectId,
                 description = projectInfo.description,
                 terraform = projectInfo.terraform?.let { TerraformSettingsScheme.from(it) }
             )


### PR DESCRIPTION
## Summary

古いYAML形式のkinfra.yamlファイルとの後方互換性をさらに強化するために、ProjectInfoSchemeに以下の変更を追加：

- 古い`name`プロパティをサポート（新しい`projectId`プロパティと同等）
- `projectId`フィールドをprivateにしてgetterで互換性を確保

## Changes

### infrastructureモジュール
- `ProjectInfoScheme`に`name`プロパティを追加（後方互換性）
- `projectIdField`をprivateフィールドとして定義
- `projectId`のgetterで古い形式と新しい形式の両方をサポート

## Benefits

- 古いYAML形式（`project.name`プロパティを使用）のkinfra.yamlファイルが正しく読み込める
- 設定ファイルの移行がスムーズに行える
- 既存ユーザーの設定ファイルが壊れない

## Test

- 古い形式のkinfra.yamlファイル（project.name形式）が正しく読み込めることを確認
- 新しい形式のファイルも正常に動作することを確認