### PR TITLE
fix: loginコマンド実行時の初期化エラーを修正

### DIFF
--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/actions/LoginAction.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/actions/LoginAction.kt
@@ -166,7 +166,15 @@ class LoginAction(
     private fun setupKinfraConfig() {
         println("${AnsiColors.BLUE}=== Kinfra Configuration ===${AnsiColors.RESET}")
 
-        if (loginRepo.kinfraConfigExists()) {
+        // Check if login config is available before accessing kinfra config
+        val hasLoginConfig = try {
+            loginRepo.loginConfig
+            true
+        } catch (e: IllegalStateException) {
+            false
+        }
+
+        if (hasLoginConfig && loginRepo.kinfraConfigExists()) {
             println("${AnsiColors.GREEN}✓${AnsiColors.RESET} Found kinfra.yaml")
             try {
                 val config = loginRepo.loadKinfraConfig()
@@ -181,7 +189,7 @@ class LoginAction(
                 println("${AnsiColors.RED}Error:${AnsiColors.RESET} Failed to read kinfra.yaml: ${e.message}")
                 println()
             }
-        } else {
+        } else if (hasLoginConfig) {
             println("${AnsiColors.YELLOW}kinfra.yaml not found${AnsiColors.RESET}")
             println("${AnsiColors.BLUE}Creating default kinfra.yaml...${AnsiColors.RESET}")
 
@@ -198,6 +206,10 @@ class LoginAction(
                 println("${AnsiColors.RED}Error:${AnsiColors.RESET} Failed to create kinfra.yaml: ${e.message}")
                 println()
             }
+        } else {
+            println("${AnsiColors.YELLOW}Login configuration not available${AnsiColors.RESET}")
+            println("${AnsiColors.BLUE}Please run 'kinfra login <github-repo>' first${AnsiColors.RESET}")
+            println()
         }
     }
 


### PR DESCRIPTION
## Summary

loginコマンド実行時に発生していた初期化エラーを修正：

- `setupKinfraConfig()`メソッドでlogin configが存在しない場合のチェックを追加
- login configが保存される前にkinfra.yamlアクセスを試行しないように修正
- login configが存在しない場合は適切なメッセージを表示

## Changes

### app-cliモジュール
- `LoginAction.setupKinfraConfig()`メソッドを修正
- login configの存在チェックを追加
- login configが存在しない場合の適切な処理を実装

## Problem

loginコマンド実行時に以下のエラーが発生：
```
Fatal error during initialization: Login config not available
java.lang.IllegalStateException: Login config not available
```

これは、login configが保存される前にkinfra.yamlファイルへのアクセスを試行していたため。

## Solution

- login configの存在を事前にチェック
- login configが存在する場合のみkinfra.yaml操作を実行
- 存在しない場合は適切なメッセージを表示

## Test

- loginコマンドが正常に実行できることを確認
- login configが存在しない場合のメッセージ表示を確認