### PR TITLE
fix: 標準入力ストリームの競合を修正

### DIFF
--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/ConfigRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/ConfigRepositoryImpl.kt
@@ -13,7 +13,6 @@ import net.kigawa.kinfra.infrastructure.logging.Logger
 
 import java.io.File
 import java.nio.file.Path
-import java.util.Scanner
 
 /**
  * 設定ファイルを操作する実装です。
@@ -65,41 +64,38 @@ class ConfigRepositoryImpl(
      */
     private fun completeMissingLoginConfig(scheme: GlobalConfigScheme): GlobalConfigScheme {
         val login = scheme.login ?: return scheme
-        
-        val scanner = Scanner(System.`in`)
+
         var modified = false
         var repo = login.repo
         var repoPath = login.repoPath
         var enabledProjects = login.enabledProjects
-        
+
         // repoが不足している場合
         if (repo.isBlank()) {
             print("リポジトリURLを入力してください (例: https://github.com/user/repo.git): ")
-            repo = scanner.nextLine().trim()
+            repo = readlnOrNull()?.trim() ?: ""
             modified = true
         }
-        
+
         // repoPathが不足している場合
         if (repoPath.toString().isBlank()) {
             val defaultPath = filePaths.baseConfigDir?.resolve("repos") ?: Path.of("./repos")
             print("リポジトリのローカルパスを入力してください (デフォルト: $defaultPath): ")
-            val input = scanner.nextLine().trim()
+            val input = readlnOrNull()?.trim() ?: ""
             repoPath = if (input.isBlank()) defaultPath.toString() else input
             modified = true
         }
-        
+
         // enabledProjectsが空の場合
         if (enabledProjects.isEmpty()) {
             print("有効なプロジェクト名をカンマ区切りで入力してください (例: project1,project2): ")
-            val input = scanner.nextLine().trim()
+            val input = readlnOrNull()?.trim() ?: ""
             if (input.isNotBlank()) {
                 enabledProjects = input.split(",").map { it.trim() }.filter { it.isNotEmpty() }
                 modified = true
             }
         }
-        
-        scanner.close()
-        
+
         return if (modified) {
             val completedLogin = LoginConfigScheme(
                 repo = repo,


### PR DESCRIPTION
## Summary

loginコマンド実行時に発生していた標準入力ストリームの競合を修正：

- `ConfigRepositoryImpl.completeMissingLoginConfig()`メソッドで`Scanner`の代わりに`readlnOrNull()`を使用
- Scannerが標準入力ストリームを消費してしまい、その後の`readlnOrNull()`が失敗する問題を解決

## Changes

### infrastructureモジュール
- `ConfigRepositoryImpl.completeMissingLoginConfig()`メソッドを修正
- `Scanner(System.in)`の使用を`readlnOrNull()`に変更
- Scannerのimportを削除

## Problem

loginコマンド実行時に以下のエラーが発生：
```
Fatal error during initialization: Stream closed
java.io.IOException: Stream closed
```

これは、`ConfigRepositoryImpl`でScannerを使用し標準入力ストリームを消費した後、`LoginAction`で`readlnOrNull()`を使用するとストリームが既に閉じられているため。

## Solution

- ScannerをreadlnOrNull()に置き換えて、標準入力ストリームの競合を回避
- 同じ入力ストリームを使用するように統一

## Test

- loginコマンドが正常に実行できることを確認
- インタラクティブ入力が正しく動作することを確認