### PR TITLE
fix: YAMLシリアライズ時のフィールド名を修正

### DIFF
--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
@@ -1,5 +1,6 @@
 package net.kigawa.kinfra.infrastructure.config
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import net.kigawa.kinfra.model.conf.*
@@ -94,6 +95,7 @@ fun toUpdateSettings(): UpdateSettings = this
 @Serializable
 data class KinfraConfigScheme(
     // Support both old and new formats for reading
+    @SerialName("rootProject")
     private val rootProjectNew: ProjectInfoScheme? = null,
     private val rootProjectField: ProjectInfoScheme? = null,
     override val bitwarden: BitwardenSettingsScheme? = null,


### PR DESCRIPTION
## Summary

YAMLシリアライズ時のフィールド名を修正して`rootProject`プロパティを正しく読み込めるように：

- `@SerialName`アノテーションを追加
- `rootProjectNew`フィールドを`rootProject`としてシリアライズ
- YAMLの`rootProject`プロパティに対応

## Changes

### infrastructureモジュール
- `KinfraConfigScheme`に`@SerialName("rootProject")`アノテーションを追加
- `rootProjectNew`フィールドをYAMLの`rootProject`プロパティとして扱う
- kotlinx.serializationのフィールド名マッピングを修正

## Problem

YAMLファイルに`rootProject`プロパティがある場合に読み込みエラーが発生：
```
Error: Failed to load configuration: Unknown property 'rootProject'. 
Known properties are: bitwarden, project, rootProjectField, rootProjectNew, subProjects, update
```

## Solution

- `@SerialName("rootProject")`でフィールド名を`rootProject`にマッピング
- YAMLの`rootProject`プロパティを正しく読み込めるように修正
- 保存時は`project`形式、読み込み時は複数の形式をサポート

## Benefits

- `rootProject`プロパティを含むYAMLファイルを正しく読み込み可能
- シリアライズ/デシリアライズの一貫性を確保
- 後方互換性を維持しつつ新しい形式もサポート