### PR TITLE
fix: ProjectInfoSchemeのシリアライズフィールド名を修正

### DIFF
--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
@@ -7,6 +7,7 @@ import net.kigawa.kinfra.model.conf.*
 
 @Serializable
 data class ProjectInfoScheme(
+    @SerialName("projectId")
     private val projectIdField: String? = null,
     override val description: String? = null,
     override val terraform: TerraformSettingsScheme? = null,


### PR DESCRIPTION
## Summary

ProjectInfoSchemeのシリアライズフィールド名を修正して`projectId`プロパティを正しく読み込めるように：

- `@SerialName`アノテーションを追加
- `projectIdField`フィールドを`projectId`としてシリアライズ
- YAMLの`projectId`プロパティに対応

## Changes

### infrastructureモジュール
- `ProjectInfoScheme`に`@SerialName("projectId")`アノテーションを追加
- `projectIdField`フィールドをYAMLの`projectId`プロパティとして扱う
- kotlinx.serializationのフィールド名マッピングを修正

## Problem

YAMLファイルに`projectId`プロパティがある場合に読み込みエラーが発生：
```
Error: Failed to load configuration: Unknown property 'projectId'. 
Known properties are: description, name, projectIdField, terraform
```

## Solution

- `@SerialName("projectId")`でフィールド名を`projectId`にマッピング
- YAMLの`projectId`プロパティを正しく読み込めるように修正
- 保存時は`name`形式、読み込み時は複数の形式をサポート

## Benefits

- `projectId`プロパティを含むYAMLファイルを正しく読み込み可能
- シリアライズ/デシリアライズの一貫性を確保
- 後方互換性を維持しつつ新しい形式もサポート