### PR TITLE
feat: Terraform設定がnullの場合に実行しない

### DIFF
--- a/.serena/memories/current_work_status.md
+++ b/.serena/memories/current_work_status.md
@@ -2,22 +2,18 @@
 
 ## ワーキングツリーの状態
 - **ブランチ**: kigawa (devと同期済み)
-- **コミット予定の変更**: なし (すべてコミット済み)
-- **ステージされていない変更**: AGENTS.mdの更新
+- **コミット予定の変更**: AGENTS.mdの更新
 
 ## 最近の作業履歴
-1. **PR #99 作成**: YAMLデシリアライズでUnknown property 'login'を無視する修正
-   - ConfigRepositoryImplでYamlConfiguration(strictMode = false)を設定
-   - Unknown propertyを含むYAMLファイルをエラーなく読み込み可能
+1. **PR #99 更新**: Terraformエラー時にプロジェクト情報を表示する機能を追加
+   - PlanAction, StatusAction, ApplyAction, DestroyAction, ValidateAction, FormatAction, InitActionでエラー発生時にプロジェクトパスを表示
 
 2. **PR #97 マージ待ち**: ドキュメント更新
 
-3. **PR #95 マージ済み**: ProjectInfoSchemeのシリアライズ修正
-
 ## 次の作業予定
 - PRのレビューとマージを待つ
-- 追加の互換性問題の監視
+- 追加の機能改善
 
 ## 注意事項
-- YAMLデシリアライズのstrictModeをfalseに設定して後方互換性を確保
-- ドキュメントを最新の状態に維持
+- Terraformエラー時にプロジェクト情報を表示することで、デバッグが容易になる
+- 複数プロジェクト管理時のユーザビリティ向上

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
-- 2025-10-20: YAMLデシリアライズエラーと入力ストリーム競合を修正。ProjectInfoSchemeに@SerialName("projectId")を追加、LoginActionでreadlnOrNull()を使用、bin/commonにgit merge origin/devを追加。ConfigRepositoryImplでstrictMode=falseを設定してUnknown propertyを無視。
+- 2025-10-20: YAMLデシリアライズエラーと入力ストリーム競合を修正。ProjectInfoSchemeに@SerialName("projectId")を追加、LoginActionでreadlnOrNull()を使用、bin/commonにgit merge origin/devを追加。ConfigRepositoryImplでstrictMode=falseを設定してUnknown propertyを無視。Terraformエラー時にプロジェクト情報を表示する機能を追加。
 - 2025-10-19: PR #95 をマージ。ProjectInfoSchemeのシリアライズフィールド名を修正してprojectIdプロパティを正しく読み込み。
 - 2025-10-19: PR #66 を作成。サブプロジェクトにディレクトリ指定機能を追加。SubProjectデータクラスを作成し、name:path形式でパス指定を可能に。sub editコマンドも追加。
 - 2025-10-19: PR #65 をマージ。config -p editコマンドの解析を修正。CommandInterpreterがフラグをスキップしてサブコマンドを正しく検出するように改善。

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
@@ -10,6 +10,13 @@ class ApplyAction(
     private val terraformService: TerraformService
 ) : Action {
     override fun execute(args: List<String>): Int {
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         // Check if first arg is a plan file
         val planFile = if (args.isNotEmpty() &&
             (args[0].endsWith(".tfplan") || args[0] == "tfplan")) {
@@ -24,7 +31,6 @@ class ApplyAction(
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DestroyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DestroyAction.kt
@@ -17,11 +17,17 @@ class DestroyAction(
             println("${AnsiColors.YELLOW}Warning:${AnsiColors.RESET} Failed to pull from git repository, continuing anyway...")
         }
 
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         val result = terraformService.destroy(args, quiet = false)
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/FormatAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/FormatAction.kt
@@ -17,11 +17,17 @@ class FormatAction(
             println("${AnsiColors.YELLOW}Warning:${AnsiColors.RESET} Failed to pull from git repository, continuing anyway...")
         }
 
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         val result = terraformService.format(recursive = true, quiet = false)
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/InitAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/InitAction.kt
@@ -18,6 +18,11 @@ class InitAction(
         }
 
         val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            ColorLogger.error("Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         ColorLogger.info("Working directory: ${config.workingDirectory.absolutePath}")
 
         val result = terraformService.init(args, quiet = false)

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
@@ -17,11 +17,17 @@ class PlanAction(
             println("${AnsiColors.YELLOW}Warning:${AnsiColors.RESET} Failed to pull from git repository, continuing anyway...")
         }
 
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         val result = terraformService.plan(args, quiet = false)
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/StatusAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/StatusAction.kt
@@ -17,11 +17,17 @@ class StatusAction(
             println("${AnsiColors.YELLOW}Warning:${AnsiColors.RESET} Failed to pull from git repository, continuing anyway...")
         }
 
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         val result = terraformService.show(args, quiet = false)
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ValidateAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ValidateAction.kt
@@ -17,11 +17,17 @@ class ValidateAction(
             println("${AnsiColors.YELLOW}Warning:${AnsiColors.RESET} Failed to pull from git repository, continuing anyway...")
         }
 
+        // Terraform設定が取得できない場合は実行しない
+        val config = terraformService.getTerraformConfig()
+        if (config == null) {
+            println("${AnsiColors.RED}Error:${AnsiColors.RESET} Terraform configuration not found. Please check your kinfra.yaml file.")
+            return 1
+        }
+
         val result = terraformService.validate(quiet = false)
 
         // エラーが発生した場合、プロジェクト情報を表示
         if (result.isFailure()) {
-            val config = terraformService.getTerraformConfig()
             println("${AnsiColors.RED}Error in project:${AnsiColors.RESET} ${config.workingDirectory.absolutePath}")
         }
 

--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/service/TerraformServiceImpl.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/service/TerraformServiceImpl.kt
@@ -17,6 +17,9 @@ class TerraformServiceImpl(
 
     override fun init(additionalArgs: List<String>, quiet: Boolean): Res<Int, ActionException> {
         val config = terraformRepository.getTerraformConfig()
+        if (config == null) {
+            return Res.Err(ActionException(1, "Terraform configuration not found"))
+        }
 
         val args = arrayOf("terraform", "init") + additionalArgs
 
@@ -30,6 +33,10 @@ class TerraformServiceImpl(
 
     override fun plan(additionalArgs: List<String>, quiet: Boolean): Res<Int, ActionException> {
         val config = terraformRepository.getTerraformConfig()
+        if (config == null) {
+            return Res.Err(ActionException(1, "Terraform configuration not found"))
+        }
+
         val varFileArgs = if (config.hasVarFile()) {
             arrayOf("-var-file=${config.varFile!!.absolutePath}")
         } else {
@@ -50,6 +57,9 @@ class TerraformServiceImpl(
         planFile: String?, additionalArgs: List<String>, quiet: Boolean,
     ): Res<Int, ActionException> {
         val config = terraformRepository.getTerraformConfig()
+        if (config == null) {
+            return Res.Err(ActionException(1, "Terraform configuration not found"))
+        }
 
         val baseArgs = arrayOf("terraform", "apply")
         val varFileArgs = if (planFile == null && config.hasVarFile()) {
@@ -71,6 +81,10 @@ class TerraformServiceImpl(
 
     override fun destroy(additionalArgs: List<String>, quiet: Boolean): Res<Int, ActionException> {
         val config = terraformRepository.getTerraformConfig()
+        if (config == null) {
+            return Res.Err(ActionException(1, "Terraform configuration not found"))
+        }
+
         val varFileArgs = if (config.hasVarFile()) {
             arrayOf("-var-file=${config.varFile!!.absolutePath}")
         } else {
@@ -103,6 +117,10 @@ class TerraformServiceImpl(
 
     override fun show(additionalArgs: List<String>, quiet: Boolean): Res<Int, ActionException> {
         val config = terraformRepository.getTerraformConfig()
+        if (config == null) {
+            return Res.Err(ActionException(1, "Terraform configuration not found"))
+        }
+
         val args = arrayOf("terraform", "show") + additionalArgs
 
         return processExecutor.execute(
@@ -113,7 +131,7 @@ class TerraformServiceImpl(
         )
     }
 
-    override fun getTerraformConfig(): TerraformConfig {
+    override fun getTerraformConfig(): TerraformConfig? {
         return terraformRepository.getTerraformConfig()
     }
 }

--- a/model/src/main/kotlin/net/kigawa/kinfra/model/service/TerraformService.kt
+++ b/model/src/main/kotlin/net/kigawa/kinfra/model/service/TerraformService.kt
@@ -15,5 +15,5 @@ interface TerraformService {
     fun format(recursive: Boolean = true, quiet: Boolean = true): Res<Int, ActionException>
     fun validate(quiet: Boolean = true): Res<Int, ActionException>
     fun show(additionalArgs: List<String>, quiet: Boolean = true): Res<Int, ActionException>
-    fun getTerraformConfig(): TerraformConfig
+    fun getTerraformConfig(): TerraformConfig?
 }


### PR DESCRIPTION
## Summary

Terraform設定が取得できない場合にTerraformコマンドを実行しない機能を追加：

- TerraformService.getTerraformConfig()をnullableに変更
- TerraformRepository.getTerraformConfig()がkinfraConfigやTerraform設定がない場合にnullを返す
- TerraformServiceImplの各メソッドでconfigがnullの場合にエラーを返す
- Actionクラスで事前にconfigチェックを行い、nullの場合は実行せずにエラーメッセージを表示
- Terraform設定ファイルが存在しない場合のエラーハンドリングを改善

## Changes

### modelモジュール
- `TerraformService.getTerraformConfig()`をnullableに変更

### infrastructureモジュール
- `TerraformRepository.getTerraformConfig()`をnullableに変更
- `TerraformRepositoryImpl.getTerraformConfig()`でkinfraConfigやTerraform設定がない場合にnullを返す
- `TerraformServiceImpl`の各メソッド(init, plan, apply, destroy, show)でconfigがnullの場合にエラーを返す

### actionモジュール
- `PlanAction`, `StatusAction`, `ApplyAction`, `DestroyAction`, `ValidateAction`, `FormatAction`, `InitAction`で事前にconfigチェック
- configがnullの場合は実行せずに適切なエラーメッセージを表示

## Problem

Terraform設定ファイルが存在しない場合でもTerraformコマンドが実行され、Terraformの標準エラーが表示される：
```
╷
│ Error: No configuration files
│ 
│ Plan requires configuration to be present. Planning without a configuration would mark everything for destruction, which is normally not what is desired. If you would like to destroy everything, run plan with the -destroy option. Otherwise, create a Terraform configuration file (.tf file) and try again.
╵
```

## Solution

- Terraform設定の取得をnullableにし、設定がない場合にnullを返す
- Actionレベルで事前に設定チェックを行い、設定がない場合はkinfra固有のエラーメッセージを表示
- Terraformコマンドの実行前に設定の存在を確認することで、無駄な実行を防ぐ

## Benefits

- Terraform設定ファイルが存在しない場合にkinfra固有のわかりやすいエラーメッセージを表示
- 不要なTerraformコマンド実行を防ぎ、処理時間を短縮
- 設定ファイルの問題を早期に検知可能