### PR TITLE
fix: GitHub Actionsワークフローで無効な条件式を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -178,7 +178,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        if: steps.claude.outcome == 'success' && ! git diff --cached --quiet
+        if: steps.claude.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-20: Terraform設定がnullの場合にエラーを出さずにスキップする。plan, apply, status, destroy, format, validate, initアクションでconfig == nullの場合に静かにreturn 0。
 - 2025-10-20: Terraformアクションのエラーメッセージを詳細に表示するように改善。plan, apply, status, destroy, format, validate, initアクションでresult.message()を表示。
 - 2025-10-20: GitHub Actionsワークフローでcreate-pull-requestアクションを使用するように修正。peter-evans/create-pull-request@v6を使用し、PR作成を自動化。
 - 2025-10-20: YAMLデシリアライズエラーと入力ストリーム競合を修正。ProjectInfoSchemeに@SerialName("projectId")を追加、LoginActionでreadlnOrNull()を使用、bin/commonにgit merge origin/devを追加。ConfigRepositoryImplでstrictMode=falseを設定してUnknown propertyを無視。Terraformエラー時にプロジェクト情報を表示する機能を追加。Terraform設定がnullの場合に実行しない機能を追加。


### PR DESCRIPTION
GitHub Actionsワークフローで、PR作成時の条件式に無効なbashコマンドが含まれていたため修正しました。

変更内容:
- Create Pull Requestステップの条件から `&& ! git diff --cached --quiet` を削除
- peter-evans/create-pull-requestアクションは変更がない場合自動的にPRを作成しないため、この条件は不要