### PR TITLE
feat: サブプロジェクトのTerraform実行がスキップされた場合に成功として扱う

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-20: plan実行前にプロジェクト名を表示する。PlanActionでterraform plan実行前に作業ディレクトリパスを表示。
 - 2025-10-20: Terraform実行がスキップされた場合に成功として扱う。DeploymentPipelineでTerraform設定が見つからないエラーをexit code 0として扱う。
 - 2025-10-20: GitHub Actionsワークフローで無効な条件式を修正。Create Pull Requestステップの条件からbashコマンドを削除。
 - 2025-10-20: Terraform設定がnullの場合にエラーを出さずにスキップする。plan, apply, status, destroy, format, validate, initアクションでconfig == nullの場合に静かにreturn 0。

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployActionWithSDK.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployActionWithSDK.kt
@@ -11,6 +11,7 @@ import net.kigawa.kinfra.model.util.AnsiColors
 import net.kigawa.kinfra.model.util.exitCode
 import net.kigawa.kinfra.model.util.isFailure
 import net.kigawa.kinfra.model.util.isSuccess
+import net.kigawa.kinfra.model.util.message
 import net.kigawa.kinfra.action.logging.Logger
 import net.kigawa.kinfra.model.BitwardenSecret
 import java.io.File
@@ -146,6 +147,12 @@ class DeployActionWithSDK(
         println("${AnsiColors.BLUE}Step 1/3: Initializing Terraform${AnsiColors.RESET}")
         val initResult = terraformService.init(emptyList())
         if (initResult.isFailure()) {
+            // Terraform設定がない場合はスキップとして成功扱い
+            if (initResult.message()?.contains("Terraform configuration not found") == true) {
+                logger.info("Terraform configuration not found for sub-project, skipping")
+                println("${AnsiColors.YELLOW}⚠ Terraform configuration not found, skipping${AnsiColors.RESET}")
+                return 0
+            }
             logger.error("Terraform init failed for sub-project with exit code: ${initResult.exitCode()}")
             return initResult.exitCode()
         }
@@ -158,6 +165,12 @@ class DeployActionWithSDK(
         println("${AnsiColors.BLUE}Step 2/3: Creating execution plan${AnsiColors.RESET}")
         val planResult = terraformService.plan(additionalArgs)
         if (planResult.isFailure()) {
+            // Terraform設定がない場合はスキップとして成功扱い
+            if (planResult.message()?.contains("Terraform configuration not found") == true) {
+                logger.info("Terraform configuration not found for sub-project, skipping")
+                println("${AnsiColors.YELLOW}⚠ Terraform configuration not found, skipping${AnsiColors.RESET}")
+                return 0
+            }
             logger.error("Terraform plan failed for sub-project with exit code: ${planResult.exitCode()}")
             return planResult.exitCode()
         }
@@ -176,6 +189,12 @@ class DeployActionWithSDK(
         val applyResult = terraformService.apply(additionalArgs = applyArgsWithAutoApprove)
 
         if (applyResult.isFailure()) {
+            // Terraform設定がない場合はスキップとして成功扱い
+            if (applyResult.message()?.contains("Terraform configuration not found") == true) {
+                logger.info("Terraform configuration not found for sub-project, skipping")
+                println("${AnsiColors.YELLOW}⚠ Terraform configuration not found, skipping${AnsiColors.RESET}")
+                return 0
+            }
             logger.error("Terraform apply failed for sub-project with exit code: ${applyResult.exitCode()}")
             return applyResult.exitCode()
         }


### PR DESCRIPTION
DeployActionWithSDKのexecuteSubProjectDeploymentで、Terraform設定が見つからない場合にスキップとして成功扱いするように変更しました。

変更内容:
- サブプロジェクトのinit, plan, applyでTerraform設定が見つからないエラーの場合にexit code 0を返す
- これにより、サブプロジェクトにTerraform設定がない場合でもデプロイ処理を継続できる