### PR TITLE
Add automatic terraform init before plan execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-24: plan実行時に自動でterraform initを実行する機能を追加。PlanActionとSubPlanActionでplan前にinitを実行するように変更。
 - 2025-10-23: tfvars生成機能を削除。DeployActionWithSDK.kt、DeployAction.kt、DeploymentPipeline.ktからbackend setupコードを削除し、Terraformワークフローを簡素化。
 - 2025-10-22: .bws_tokenファイルを~/.local/kinfra/.bws_tokenに配置するように修正。
 - 2025-10-22: GlobalConfigCompleterインターフェースを実装し、設定補完機能を追加。

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubPlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubPlanAction.kt
@@ -50,6 +50,20 @@ class SubPlanAction(
 
         // サブプロジェクトでplanを実行
         val result = subProjectExecutor.executeInSubProjects(listOf(subProject)) { _, subProjectDir ->
+            // plan前にinitを実行
+            println("${AnsiColors.BLUE}Initializing Terraform for sub-project ${subProject.name}...${AnsiColors.RESET}")
+            val initProcess = ProcessBuilder("terraform", "init")
+                .directory(subProjectDir)
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+
+            val initExitCode = initProcess.waitFor()
+            if (initExitCode != 0) {
+                println("${AnsiColors.RED}Terraform init failed for sub-project ${subProject.name}${AnsiColors.RESET}")
+                return@executeInSubProjects initExitCode
+            }
+
             // サブプロジェクトディレクトリでterraform planを実行
             val process = ProcessBuilder("terraform", "plan")
                 .directory(subProjectDir)


### PR DESCRIPTION
## 概要

このPRでは、planコマンド実行時に自動的にterraform initを実行する機能を追加します。これにより、ユーザーは手動でinitを実行する必要がなくなり、ワークフローが簡素化されます。

## 変更内容

### PlanAction.kt
- 親プロジェクトのplan実行前に自動でterraform initを実行
- サブプロジェクトのplan実行前に自動でterraform initを実行

### SubPlanAction.kt
- サブプロジェクトのplan実行前に自動でterraform initを実行

### AGENTS.md
- 変更履歴に今回の機能を追加

## 影響

- planコマンドの実行がより便利になる
- initの手動実行が不要になる
- 既存のplan機能に破壊的変更はない