### PR TITLE
Add Bitwarden secret to Terraform variable mapping in kinfra.yml

### DIFF
--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
@@ -65,7 +65,7 @@ class DependencyContainer {
     val globalConfigCompleter: GlobalConfigCompleter by lazy { GlobalConfigCompleterImpl(filePaths) }
     val configRepository: ConfigRepository by lazy { ConfigRepositoryImpl(filePaths, logger, globalConfigCompleter) }
     val terraformRepository by lazy { TerraformRepositoryImpl(fileRepository, configRepository) }
-    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository) }
+    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository) }
     val bitwardenRepository: BitwardenRepository by lazy { BitwardenRepositoryImpl(processExecutor, filePaths) }
 
     val globalConfig: GlobalConfig by lazy {

--- a/app-web/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
+++ b/app-web/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
@@ -58,7 +58,7 @@ class DependencyContainer {
     val processExecutor: ProcessExecutor by lazy { ProcessExecutorImpl() }
     val configRepository: ConfigRepository by lazy { ConfigRepositoryImpl(filePaths, logger, globalConfigCompleter) }
     val terraformRepository: TerraformRepository by lazy { TerraformRepositoryImpl(fileRepository, configRepository) }
-    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository) }
+    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository) }
     val bitwardenRepository: BitwardenRepository by lazy { BitwardenRepositoryImpl(processExecutor, filePaths) }
 
     // Bitwarden Secret Manager

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -89,6 +89,12 @@ export KINFRA_LOG_DIR=/var/log/kinfra
 
 **例** (新しい形式):
 
+**variableMappings**: BitwardenのシークレットとTerraform変数のマッピングを定義します。各マッピングは以下のフィールドを持ちます:
+- `terraformVariable`: Terraformで使用する変数名
+- `bitwardenSecretKey`: Bitwardenのシークレットキー
+
+plan/apply実行時に、これらのマッピングに基づいて`secrets.tfvars`ファイルが自動生成され、Terraform変数として使用されます。
+
 ```yaml
 project:
   projectId: "my-infrastructure"
@@ -96,6 +102,11 @@ project:
   terraform:
     version: "1.5.0"
     workingDirectory: "."
+    variableMappings:
+      - terraformVariable: "cloudflare_api_token"
+        bitwardenSecretKey: "cloudflare-api-token"
+      - terraformVariable: "aws_access_key"
+        bitwardenSecretKey: "aws-access-key"
 
 bitwarden:
   projectId: "your-bitwarden-project-id"

--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
@@ -32,10 +32,19 @@ data class ProjectInfoScheme(
     }
 }
 
+
+
+@Serializable
+data class TerraformVariableMappingScheme(
+    override val terraformVariable: String,
+    override val bitwardenSecretKey: String
+) : TerraformVariableMapping
+
 @Serializable
 data class TerraformSettingsScheme(
     override val version: String = "",
-    override val workingDirectory: String = "."
+    override val workingDirectory: String = ".",
+    override val variableMappings: List<TerraformVariableMappingScheme> = emptyList()
 ) : TerraformSettings {
     companion object {
         fun from(settings: TerraformSettings): TerraformSettingsScheme {
@@ -44,11 +53,17 @@ data class TerraformSettingsScheme(
             }
             return TerraformSettingsScheme(
                 version = settings.version,
-                workingDirectory = settings.workingDirectory
+                workingDirectory = settings.workingDirectory,
+                variableMappings = settings.variableMappings.map {
+                    TerraformVariableMappingScheme(
+                        terraformVariable = it.terraformVariable,
+                        bitwardenSecretKey = it.bitwardenSecretKey
+                    )
+                }
             )
         }
     }
-    
+
     fun toTerraformSettings(): TerraformSettings = this
 }
 

--- a/model/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraConfig.kt
+++ b/model/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraConfig.kt
@@ -3,13 +3,13 @@ package net.kigawa.kinfra.model.conf
 import net.kigawa.kinfra.model.conf.global.LoginConfig
 
 interface KinfraConfig {
-     val rootProject: ProjectInfo
-     val bitwarden: BitwardenSettings?
-     val subProjects: List<ProjectInfo>
-     val update: UpdateSettings?
-     @Deprecated("Login configuration should be in GlobalConfig. This property is kept for backward compatibility.")
-     val login: LoginConfig?
- }
+      val rootProject: ProjectInfo
+      val bitwarden: BitwardenSettings?
+      val subProjects: List<ProjectInfo>
+      val update: UpdateSettings?
+      @Deprecated("Login configuration should be in GlobalConfig. This property is kept for backward compatibility.")
+      val login: LoginConfig?
+  }
 
 interface ProjectInfo {
     val projectId: String
@@ -17,9 +17,16 @@ interface ProjectInfo {
     val terraform: TerraformSettings?
 }
 
+interface TerraformVariableMapping {
+    val terraformVariable: String
+    val bitwardenSecretKey: String
+}
+
 interface TerraformSettings {
     val version: String
     val workingDirectory: String
+    val variableMappings: List<TerraformVariableMapping>
+        get() = emptyList()
 }
 
 interface BitwardenSettings {


### PR DESCRIPTION
## 概要

このPRでは、kinfra.ymlでBitwardenのシークレットとTerraform変数のマッピングを定義できる機能を追加します。これにより、Terraform実行時に自動的にBitwardenからシークレットを取得して.tfvarsファイルに設定できます。

## 変更内容

### kinfra.ymlスキーマの拡張
- `TerraformVariableMapping`インターフェースをmodelモジュールに追加
- `TerraformVariableMappingScheme`を実装クラスとしてinfrastructureモジュールに追加
- `TerraformSettings`に`variableMappings`フィールドを追加

### Terraform実行時の自動.tfvars生成
- `TerraformServiceImpl`でBitwardenシークレットから`secrets.tfvars`ファイルを生成
- plan/apply実行時にマッピングに基づいて自動生成
- 既存のvarFileと組み合わせて使用可能

### 依存関係の管理
- modelモジュールに外部ライブラリの依存関係を追加せず、interfaceを使用
- infrastructureモジュールでのみkotlinx-serializationを使用

### ドキュメント更新
- `docs/configuration-reference.md`に`variableMappings`の説明と例を追加

## 使用例

kinfra.ymlに以下のように記述することで、BitwardenのシークレットをTerraform変数にマッピングできます：

```yaml
terraform:
  variableMappings:
    - terraformVariable: "cloudflare_api_token"
      bitwardenSecretKey: "cloudflare-api-token"
    - terraformVariable: "aws_access_key"
      bitwardenSecretKey: "aws-access-key"
```

plan/apply実行時に、これらのマッピングに基づいて`secrets.tfvars`ファイルが自動生成され、Terraform変数として使用されます。

## 影響

- kinfra.ymlでシークレット管理が宣言的に可能になる
- Terraform実行時の手動設定が不要になる
- セキュリティが向上（シークレットがコードにハードコードされない）