### PR TITLE
Fix backend.tfvars generation and CLI input issue

### DIFF
--- a/app-cli/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
+++ b/app-cli/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
@@ -65,7 +65,7 @@ class DependencyContainer {
     val globalConfigCompleter: GlobalConfigCompleter by lazy { GlobalConfigCompleterImpl(filePaths) }
     val configRepository: ConfigRepository by lazy { ConfigRepositoryImpl(filePaths, logger, globalConfigCompleter) }
     val terraformRepository by lazy { TerraformRepositoryImpl(fileRepository, configRepository) }
-    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository) }
+    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository, bitwardenRepository) }
     val bitwardenRepository: BitwardenRepository by lazy { BitwardenRepositoryImpl(processExecutor, filePaths) }
 
     val globalConfig: GlobalConfig by lazy {

--- a/app-web/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
+++ b/app-web/src/main/kotlin/net/kigawa/kinfra/di/DependencyContainer.kt
@@ -58,7 +58,7 @@ class DependencyContainer {
     val processExecutor: ProcessExecutor by lazy { ProcessExecutorImpl() }
     val configRepository: ConfigRepository by lazy { ConfigRepositoryImpl(filePaths, logger, globalConfigCompleter) }
     val terraformRepository: TerraformRepository by lazy { TerraformRepositoryImpl(fileRepository, configRepository) }
-    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository) }
+    val terraformService: TerraformService by lazy { TerraformServiceImpl(processExecutor, terraformRepository, configRepository, bitwardenSecretManagerRepository, bitwardenRepository) }
     val bitwardenRepository: BitwardenRepository by lazy { BitwardenRepositoryImpl(processExecutor, filePaths) }
 
     // Bitwarden Secret Manager


### PR DESCRIPTION
## 概要

このPRでは、Terraformのplan/apply実行時にCLIでバックエンド設定の入力を求められる問題を修正します。

## 問題

以前のplan実行で、TerraformがS3バックエンドの設定（バケット名など）をインタラクティブに入力するよう求められていました。これはbackend.tfvarsファイルが正しく生成されていないためです。

## 変更内容

### TerraformServiceImplの修正
- `generateBackendTfvarsFromBitwarden()`メソッドでBitwardenからS3バックエンド設定を取得
- plan/applyコマンドに`-backend-config`引数を追加してbackend.tfvarsファイルを指定
- backend.tfvars生成失敗時の警告ログを追加

### 依存関係の更新
- `TerraformServiceImpl`に`BitwardenRepository`を注入
- `DependencyContainer`で`BitwardenRepository`の依存関係を追加

## 動作

1. plan/apply実行時にBitwardenからバックエンド設定を取得
2. `backend.tfvars`ファイルを自動生成
3. Terraformコマンドに`-backend-config`引数を渡して非対話型実行を実現

これにより、CLIで手動入力することなくTerraformを実行できるようになります。