### PR TITLE
Issue #169修正: kinfra planのバックエンド設定マージ問題を解決

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-28: Issue #169を修正。`kinfra plan`コマンドのバックエンド設定マージ問題を解決。SubProjectExecutorにgetMergedBackendConfigメソッドを追加し、親プロジェクト(kinfra-parent.yaml)とサブプロジェクト(kinfra.yaml)のbackendConfigを正しくマージするように修正。PlanActionとCurrentPlanActionでマージされた設定を使用するように変更。
 - 2025-10-26: Claudeワークフローのclaude_argsパラメータのYAMLインデントを修正。
 - 2025-10-26: PR #167 を作成。ログ出力、ドキュメント、アクション処理の改善を実装。
 - 2025-10-26: NextActionを修正。`kinfra next` コマンドでローカル変更がある場合に自動stashしてpullし、変更があったサブプロジェクトのみを有効化。stash復元時にコンフリクトが発生した場合でも処理を続行。divergent branchesがある場合に--no-rebaseオプションでpullする機能を追加。

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
@@ -60,8 +60,8 @@ class PlanAction(
             val subResult = subProjectExecutor.executeInSubProjects(subProjects) { subProject, subProjectDir ->
                 println("${AnsiColors.BLUE}Planning Terraform changes for sub-project:${AnsiColors.RESET} ${subProject.name} (${subProjectDir.absolutePath})")
 
-                // サブプロジェクトのbackendConfigを読み込み
-                val backendConfig = subProjectExecutor.getBackendConfig()
+                // サブプロジェクトのマージされたbackendConfigを読み込み
+                val backendConfig = subProjectExecutor.getMergedBackendConfig(subProject)
 
                 // サブプロジェクトでもplan前にinitを実行
                 println("${AnsiColors.BLUE}Initializing Terraform for sub-project...${AnsiColors.RESET}")


### PR DESCRIPTION
## 概要
`kinfra plan`コマンドでS3バックエンド設定時に"Missing Required Value"エラーが発生する問題を修正しました。親プロジェクトとサブプロジェクトのバックエンド設定を正しくマージするように改善しました。

## 問題
`kinfra plan <sub-project>`を実行する際、親プロジェクトの`kinfra-parent.yaml`からしかバックエンド設定を読み込んでおらず、サブプロジェクトの`kinfra.yaml`の設定が無視されていました。これにより、S3バックエンドで必須の"bucket"などの値が正しく設定されず、エラーが発生していました。

## 解決策
- **SubProjectExecutor**: `getMergedBackendConfig()`メソッドを追加し、親プロジェクト(kinfra-parent.yaml)とサブプロジェクト(kinfra.yaml)のバックエンド設定をマージ
- **PlanAction**: サブプロジェクト実行時にマージされたバックエンド設定を使用するように修正
- **CurrentPlanAction**: カレントディレクトリでのplan実行時にも両方の設定ファイルをマージするように修正
- サブプロジェクトの設定が親プロジェクトの設定を正しく上書きするように優先順位を設定

## 変更内容
- `SubProjectExecutor.getMergedBackendConfig()`: 親プロジェクトとサブプロジェクトの設定を読み込んでマージする新メソッド
- `PlanAction`: サブプロジェクト操作で`getMergedBackendConfig()`を使用するように更新
- `CurrentPlanAction`: 両方の設定ファイルから設定をマージするように更新
- 設定のマージ優先順位: サブプロジェクト設定 > 親プロジェクト設定

## 結果
`kinfra plan <sub-project>`コマンドがS3バックエンド設定で正しく動作するようになり、バックエンド設定が期待通りにマージ・上書きされるようになりました。

修正対象: #169