### PR TITLE
Fix compilation errors in backend config type and serialization imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-29: コンパイルエラーを修正。SubProjectExecutor.ktのsubProjectBackendConfigの型をMap<String, String>からMap<String, Any>に変更。KinfraConfigScheme.ktにkotlinx.serialization.Contextualのインポートを追加。
 - 2025-10-28: Issue #169を修正。`kinfra plan`コマンドのバックエンド設定マージ問題を解決。SubProjectExecutorにgetMergedBackendConfigメソッドを追加し、親プロジェクト(kinfra-parent.yaml)とサブプロジェクト(kinfra.yaml)のbackendConfigを正しくマージするように修正。PlanActionとCurrentPlanActionでマージされた設定を使用するように変更。
 - 2025-10-26: Claudeワークフローのclaude_argsパラメータのYAMLインデントを修正。
 - 2025-10-26: PR #167 を作成。ログ出力、ドキュメント、アクション処理の改善を実装。

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/execution/SubProjectExecutor.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/execution/SubProjectExecutor.kt
@@ -61,7 +61,7 @@ class SubProjectExecutor(
         val subProjectDir = loginRepo.repoPath.resolve(subProject.path).toFile()
         val subProjectConfigPath = subProjectDir.resolve("kinfra.yaml")
         
-        val subProjectBackendConfig: Map<String, String> = if (subProjectConfigPath.exists()) {
+        val subProjectBackendConfig: Map<String, Any> = if (subProjectConfigPath.exists()) {
             val config = configRepository.loadKinfraConfig(subProjectConfigPath.toPath())
             config?.rootProject?.terraform?.backendConfig ?: emptyMap()
         } else {

--- a/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
+++ b/infrastructure/src/main/kotlin/net/kigawa/kinfra/infrastructure/config/KinfraConfigScheme.kt
@@ -1,5 +1,6 @@
 package net.kigawa.kinfra.infrastructure.config
 
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient


### PR DESCRIPTION
Fix compilation errors that were preventing the build from succeeding.

## Changes
- Fix type mismatch in SubProjectExecutor.kt: change subProjectBackendConfig type from Map<String, String> to Map<String, Any> to match the backendConfig interface
- Add missing import for kotlinx.serialization.Contextual in KinfraConfigScheme.kt for proper serialization of Any types
- Update AGENTS.md with the fix details

## Testing
- Build passes successfully with ./gradlew build
- All modules compile without errors

This resolves the compilation errors that were blocking development.