### PR TITLE
PR作成・更新時に自動でClaudeコードレビューを実行するように設定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,8 +2,8 @@ name: Claude Code Review
 
 on:
   workflow_dispatch:
-#  pull_request:
-#    types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 | todo-maintainer    | タスク管理を自動化するエージェント |
 
 ## 変更履歴
+- 2025-10-29: claude-code-review.ymlを編集し、PR作成時および更新時に自動でClaudeがコードレビューを行うようにpull_requestトリガーを有効化。
 - 2025-10-28: SubProjectExecutor.ktのgetMergedBackendConfigメソッドで、subProjectBackendConfigの型をMap<String, String>からMap<String, Any>に修正。backendConfigがMap<String, Any>であるため。KinfraConfigScheme.ktにkotlinx.serialization.Contextualのインポートを追加。
 - 2025-10-28: Issue #169を修正。`kinfra plan`コマンドのバックエンド設定マージ問題を解決。SubProjectExecutorにgetMergedBackendConfigメソッドを追加し、親プロジェクト(kinfra-parent.yaml)とサブプロジェクト(kinfra.yaml)のbackendConfigを正しくマージするように修正。PlanActionとCurrentPlanActionでマージされた設定を使用するように変更。
 - 2025-10-26: Claudeワークフローのclaude_argsパラメータのYAMLインデントを修正。


### PR DESCRIPTION
このPRでは、プルリクエストが作成された時または更新された時に自動でClaudeがコードレビューを実行するようにGitHub Actionsワークフローを変更します。

## 変更内容
- .github/workflows/claude-code-review.yml の pull_request トリガーを有効化（'opened' および 'synchronize' イベント）
- AGENTS.md の変更履歴にワークフロー変更を記載

## 影響
PRが作成された時やコミットがプッシュされて更新された時に、Claudeが自動的にコードレビューを実行し、コード品質・ベストプラクティス・潜在的なバグ・パフォーマンス・セキュリティ・テストカバレッジに関するフィードバックをコメントとして投稿します。