### PR TITLE
fix: add workflow_call trigger to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev
+  workflow_call:
 
 jobs:
   ktcp:


### PR DESCRIPTION
## Summary
- `ci.yml` に `workflow_call` トリガーを追加
- `renovate-merge.yml` から `uses: ./.github/workflows/ci.yml` で呼び出すために必要

## Test plan
- [ ] renovateブランチのPRで `renovate-merge.yml` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)