### PR TITLE
feat: kigawa-net GitHub App用トークン発行アクションを追加

### DIFF
--- a/.github/actions/kigawa-net-app-token/README.md
+++ b/.github/actions/kigawa-net-app-token/README.md
@@ -4,23 +4,29 @@ Reusable composite action that mints a short-lived installation token for the
 `kigawa-net` GitHub App (app_id `4316503`, `contents:write` on all org repos),
 so workflows can stop relying on the shared long-lived `GIT_TOKEN` PAT.
 
+**Flow: custom action (this) -> admin-panel -> GitHub App.** The App's
+private key lives only on the admin-panel server (kigawa-net/admin-panel#41,
+kigawa-net/admin-panel#46); this action never sees it. It authenticates to
+admin-panel's broker endpoint (`POST /api/github-app/ci-token`) with a shared
+CI token instead.
+
 ## One-time org setup (manual, do once)
 
-1. On the App's settings page (org Settings → Developer settings → GitHub Apps →
-   `kigawa-net`), click **Generate a private key** and download the `.pem` file.
-2. Register it as an **organization secret** (Settings → Secrets and variables →
-   Actions → Organization secrets), visible to the repos that need it:
-   - Name: `KIGAWA_NET_APP_PRIVATE_KEY`
-   - Value: contents of the downloaded `.pem` file
+1. On admin-panel's side, an org admin generates the App's private key
+   (App settings → Generate a private key) and registers it as the
+   `admin-panel-github-app` k8s Secret (`private-key` key) — see
+   kigawa-net/admin-panel#46.
+2. Pick a random shared secret and register it **twice**, with the same value:
+   - As the `ci-token` key in the same `admin-panel-github-app` k8s Secret
+     (admin-panel reads it as `GITHUB_APP_CI_TOKEN`).
+   - As an **organization-level GitHub Actions secret** named
+     `ADMIN_PANEL_CI_TOKEN`, visible to the repos that need it.
 
-   Or via `gh` (must be run by an org admin, with the `.pem` file at hand):
+   Example for generating the value:
 
    ```bash
-   gh secret set KIGAWA_NET_APP_PRIVATE_KEY --org kigawa-net --visibility all < app-private-key.pem
+   openssl rand -hex 32
    ```
-
-The App ID (`4316503`) is not sensitive and is baked in as this action's default,
-so no separate `APP_ID` secret is needed.
 
 ## Usage
 
@@ -29,7 +35,7 @@ so no separate `APP_ID` secret is needed.
   id: app-token
   uses: kigawa-net/kinfra/.github/actions/kigawa-net-app-token@main
   with:
-    private-key: ${{ secrets.KIGAWA_NET_APP_PRIVATE_KEY }}
+    ci-token: ${{ secrets.ADMIN_PANEL_CI_TOKEN }}
 
 - name: Checkout
   uses: actions/checkout@v4
@@ -39,9 +45,9 @@ so no separate `APP_ID` secret is needed.
 # ... later, `git push` in this checkout authenticates as the App automatically.
 ```
 
-To scope the token to specific repos (e.g. from a workflow in one repo that
-needs to push to another), pass `repositories`:
+To scope the token to specific repos or a permission subset:
 
 ```yaml
     repositories: kigawa-net-k8s
+    permissions: '{"contents":"write"}'
 ```

--- a/.github/actions/kigawa-net-app-token/README.md
+++ b/.github/actions/kigawa-net-app-token/README.md
@@ -14,19 +14,17 @@ CI token instead.
 
 1. On admin-panel's side, an org admin generates the App's private key
    (App settings → Generate a private key) and registers it as the
-   `admin-panel-github-app` k8s Secret (`private-key` key) — see
+   `admin-panel-github-app` k8s Secret (`private-key` key), via the
+   `BitwardenSecret` CRD in `k8s/base/github-app-bws.yaml` — see
    kigawa-net/admin-panel#46.
-2. Pick a random shared secret and register it **twice**, with the same value:
-   - As the `ci-token` key in the same `admin-panel-github-app` k8s Secret
-     (admin-panel reads it as `GITHUB_APP_CI_TOKEN`).
-   - As an **organization-level GitHub Actions secret** named
-     `ADMIN_PANEL_CI_TOKEN`, visible to the repos that need it.
-
-   Example for generating the value:
-
-   ```bash
-   openssl rand -hex 32
-   ```
+2. The shared CI token is generated and wired up entirely by Terraform
+   (`platform/admin-panel` in kigawa-net/infra#35): it's stored in Bitwarden
+   as the `ci-token` key of the same `admin-panel-github-app` k8s Secret,
+   *and* registered directly as the organization-level GitHub Actions
+   secret `ADMIN_PANEL_CI_TOKEN` (visible only to admin-panel and kinfra) —
+   no manual `gh secret set` needed. The only remaining manual step is
+   minting the `admin:org`-scoped GitHub PAT that module's `github` provider
+   authenticates with; see kigawa-net/infra#35 for details.
 
 ## Usage
 

--- a/.github/actions/kigawa-net-app-token/README.md
+++ b/.github/actions/kigawa-net-app-token/README.md
@@ -1,0 +1,47 @@
+# kigawa-net-app-token
+
+Reusable composite action that mints a short-lived installation token for the
+`kigawa-net` GitHub App (app_id `4316503`, `contents:write` on all org repos),
+so workflows can stop relying on the shared long-lived `GIT_TOKEN` PAT.
+
+## One-time org setup (manual, do once)
+
+1. On the App's settings page (org Settings → Developer settings → GitHub Apps →
+   `kigawa-net`), click **Generate a private key** and download the `.pem` file.
+2. Register it as an **organization secret** (Settings → Secrets and variables →
+   Actions → Organization secrets), visible to the repos that need it:
+   - Name: `KIGAWA_NET_APP_PRIVATE_KEY`
+   - Value: contents of the downloaded `.pem` file
+
+   Or via `gh` (must be run by an org admin, with the `.pem` file at hand):
+
+   ```bash
+   gh secret set KIGAWA_NET_APP_PRIVATE_KEY --org kigawa-net --visibility all < app-private-key.pem
+   ```
+
+The App ID (`4316503`) is not sensitive and is baked in as this action's default,
+so no separate `APP_ID` secret is needed.
+
+## Usage
+
+```yaml
+- name: Get GitHub App token
+  id: app-token
+  uses: kigawa-net/kinfra/.github/actions/kigawa-net-app-token@main
+  with:
+    private-key: ${{ secrets.KIGAWA_NET_APP_PRIVATE_KEY }}
+
+- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+
+# ... later, `git push` in this checkout authenticates as the App automatically.
+```
+
+To scope the token to specific repos (e.g. from a workflow in one repo that
+needs to push to another), pass `repositories`:
+
+```yaml
+    repositories: kigawa-net-k8s
+```

--- a/.github/actions/kigawa-net-app-token/action.yml
+++ b/.github/actions/kigawa-net-app-token/action.yml
@@ -1,37 +1,72 @@
 name: 'kigawa-net App Token'
 description: >-
   Mints a short-lived installation access token for the "kigawa-net" GitHub App
-  (app_id 4316503, contents:write), for use in place of a long-lived PAT such
-  as the shared GIT_TOKEN secret. Wraps actions/create-github-app-token.
+  (app_id 4316503, contents:write) by calling admin-panel's GitHub App broker
+  endpoint. The App's private key lives only on admin-panel; this action (and
+  the CI workflows using it) only ever handles a shared CI token, never the
+  key itself. Flow: custom action -> admin-panel -> GitHub App.
 inputs:
-  private-key:
+  ci-token:
     description: >-
-      PEM private key for the kigawa-net GitHub App. Pass via a secret, e.g.
-      ${{ secrets.KIGAWA_NET_APP_PRIVATE_KEY }}.
+      Shared secret for admin-panel's CI token endpoint. Pass via
+      ${{ secrets.ADMIN_PANEL_CI_TOKEN }}.
     required: true
-  app-id:
-    description: 'GitHub App ID. Defaults to the kigawa-net app.'
-    required: false
-    default: '4316503'
   owner:
-    description: 'Restrict the token to this owner. Defaults to the calling repository owner.'
+    description: 'GitHub org/user to scope the token to.'
     required: false
+    default: 'kigawa-net'
   repositories:
     description: >-
       Newline- or comma-separated repo names (without owner) to scope the
-      token to. Defaults to the calling repository only.
+      token to. Defaults to every repo the App can access for the owner.
     required: false
+  permissions:
+    description: >-
+      JSON object of a permission subset to request, e.g. {"contents":"write"}.
+      Defaults to the App's full granted permissions.
+    required: false
+  admin-panel-url:
+    description: 'Base URL of the admin-panel API.'
+    required: false
+    default: 'https://admin.kigawa.net/api'
 outputs:
   token:
     description: 'Short-lived installation access token'
-    value: ${{ steps.app-token.outputs.token }}
+    value: ${{ steps.request-token.outputs.token }}
 runs:
   using: 'composite'
   steps:
-    - id: app-token
-      uses: actions/create-github-app-token@v3
-      with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
-        owner: ${{ inputs.owner }}
-        repositories: ${{ inputs.repositories }}
+    - id: request-token
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        repos_json="null"
+        if [ -n "${{ inputs.repositories }}" ]; then
+          repos_json=$(printf '%s' "${{ inputs.repositories }}" | tr ',\n' '\n' | sed '/^[[:space:]]*$/d' | jq -R . | jq -s .)
+        fi
+
+        perms_json="${{ inputs.permissions }}"
+        if [ -z "$perms_json" ]; then
+          perms_json="null"
+        fi
+
+        body=$(jq -n \
+          --arg owner "${{ inputs.owner }}" \
+          --argjson repositories "$repos_json" \
+          --argjson permissions "$perms_json" \
+          '{owner: $owner, repositories: $repositories, permissions: $permissions}')
+
+        response=$(curl -sS -f -X POST "${{ inputs.admin-panel-url }}/github-app/ci-token" \
+          -H "X-CI-Token: ${{ inputs.ci-token }}" \
+          -H "Content-Type: application/json" \
+          -d "$body")
+
+        token=$(printf '%s' "$response" | jq -r .token)
+        if [ -z "$token" ] || [ "$token" = "null" ]; then
+          echo "::error::admin-panel did not return a token"
+          exit 1
+        fi
+
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"

--- a/.github/actions/kigawa-net-app-token/action.yml
+++ b/.github/actions/kigawa-net-app-token/action.yml
@@ -1,0 +1,37 @@
+name: 'kigawa-net App Token'
+description: >-
+  Mints a short-lived installation access token for the "kigawa-net" GitHub App
+  (app_id 4316503, contents:write), for use in place of a long-lived PAT such
+  as the shared GIT_TOKEN secret. Wraps actions/create-github-app-token.
+inputs:
+  private-key:
+    description: >-
+      PEM private key for the kigawa-net GitHub App. Pass via a secret, e.g.
+      ${{ secrets.KIGAWA_NET_APP_PRIVATE_KEY }}.
+    required: true
+  app-id:
+    description: 'GitHub App ID. Defaults to the kigawa-net app.'
+    required: false
+    default: '4316503'
+  owner:
+    description: 'Restrict the token to this owner. Defaults to the calling repository owner.'
+    required: false
+  repositories:
+    description: >-
+      Newline- or comma-separated repo names (without owner) to scope the
+      token to. Defaults to the calling repository only.
+    required: false
+outputs:
+  token:
+    description: 'Short-lived installation access token'
+    value: ${{ steps.app-token.outputs.token }}
+runs:
+  using: 'composite'
+  steps:
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}


### PR DESCRIPTION
## Summary
`.github/actions/kigawa-net-app-token`: 再利用可能なcomposite actionを追加/更新。

**flow: custom action(this) -> admin-panel -> GitHub App**

GitHub App `kigawa-net`(app_id 4316503, `contents:write`, 全リポジトリにインストール済み)のインストールトークンを、Appの秘密鍵を直接扱う`actions/create-github-app-token`ではなく、admin-panelのCI向けブローカーエンドポイント(`POST /api/github-app/ci-token`, kigawa-net/admin-panel#46)を叩いて取得する構成に変更しました。GitHub App秘密鍵はadmin-panelサーバーだけが保持し、GitHub Actions側は共有シークレット(`ADMIN_PANEL_CI_TOKEN`)だけを扱います。

## 前提: 未実施の手動セットアップ
1. kigawa-net/admin-panel#46 側で秘密鍵とCI用共有シークレットをk8sシークレット `admin-panel-github-app`(`private-key`, `ci-token`)として登録
2. 同じ`ci-token`の値を組織シークレット `ADMIN_PANEL_CI_TOKEN` として登録

詳細は `.github/actions/kigawa-net-app-token/README.md` 参照。

Part of kigawa-net/admin-panel#41

## Test plan
- [ ] 上記シークレットを登録
- [ ] kigawa-net/admin-panel#44 (build-push.yml) からこのactionを呼び出し、トークン発行→checkout→pushが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)