### PR TITLE
feat: R2変更検出フィルタのbucket/endpointをbackendConfigから分離

### DIFF
--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
@@ -162,8 +162,11 @@ class ApplyAction(
                 executor.getBackendConfig(),
                 bitwardenSecretManagerRepository,
             )
+        val (r2Bucket, r2Endpoint) = executor.getR2Config()
+        val resolvedR2Bucket = BackendConfigResolver.resolveValue(r2Bucket, bitwardenSecretManagerRepository)
+        val resolvedR2Endpoint = BackendConfigResolver.resolveValue(r2Endpoint, bitwardenSecretManagerRepository)
         val parentProjectName = executor.getParentProjectName() ?: return SubProjectChangeFilter.NOOP
-        return factory.create(resolvedBackendConfig, parentProjectName)
+        return factory.create(resolvedBackendConfig, resolvedR2Bucket, resolvedR2Endpoint, parentProjectName)
     }
 
     override fun getDescription(): String {

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployAction.kt
@@ -128,8 +128,11 @@ class DeployAction(
                 subProjectExecutor.getBackendConfig(),
                 bitwardenSecretManagerRepository,
             )
+        val (r2Bucket, r2Endpoint) = subProjectExecutor.getR2Config()
+        val resolvedR2Bucket = BackendConfigResolver.resolveValue(r2Bucket, bitwardenSecretManagerRepository)
+        val resolvedR2Endpoint = BackendConfigResolver.resolveValue(r2Endpoint, bitwardenSecretManagerRepository)
         val parentProjectName = subProjectExecutor.getParentProjectName() ?: return SubProjectChangeFilter.NOOP
-        return factory.create(resolvedBackendConfig, parentProjectName)
+        return factory.create(resolvedBackendConfig, resolvedR2Bucket, resolvedR2Endpoint, parentProjectName)
     }
 
     override fun getDescription(): String {

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployActionWithSDK.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/DeployActionWithSDK.kt
@@ -235,8 +235,11 @@ class DeployActionWithSDK(
                 subProjectExecutor.getBackendConfig(),
                 bitwardenSecretManagerRepository,
             )
+        val (r2Bucket, r2Endpoint) = subProjectExecutor.getR2Config()
+        val resolvedR2Bucket = BackendConfigResolver.resolveValue(r2Bucket, bitwardenSecretManagerRepository)
+        val resolvedR2Endpoint = BackendConfigResolver.resolveValue(r2Endpoint, bitwardenSecretManagerRepository)
         val parentProjectName = subProjectExecutor.getParentProjectName() ?: return SubProjectChangeFilter.NOOP
-        return factory.create(resolvedBackendConfig, parentProjectName)
+        return factory.create(resolvedBackendConfig, resolvedR2Bucket, resolvedR2Endpoint, parentProjectName)
     }
 
     override fun getDescription(): String {

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
@@ -140,8 +140,11 @@ class PlanAction(
                 subProjectExecutor.getBackendConfig(),
                 bitwardenSecretManagerRepository,
             )
+        val (r2Bucket, r2Endpoint) = subProjectExecutor.getR2Config()
+        val resolvedR2Bucket = BackendConfigResolver.resolveValue(r2Bucket, bitwardenSecretManagerRepository)
+        val resolvedR2Endpoint = BackendConfigResolver.resolveValue(r2Endpoint, bitwardenSecretManagerRepository)
         val parentProjectName = subProjectExecutor.getParentProjectName() ?: return SubProjectChangeFilter.NOOP
-        return factory.create(resolvedBackendConfig, parentProjectName)
+        return factory.create(resolvedBackendConfig, resolvedR2Bucket, resolvedR2Endpoint, parentProjectName)
     }
 
     override fun getDescription(): String {

--- a/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/conf/BackendConfigResolver.kt
+++ b/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/conf/BackendConfigResolver.kt
@@ -29,6 +29,18 @@ object BackendConfigResolver {
         }
     }
 
+    /**
+     * 単一のnullable String値（r2Bucket/r2Endpoint等、backendConfigのMapに属さない値）に
+     * 含まれ得る`bws(...)`マーカーを解決する。
+     */
+    fun resolveValue(
+        value: String?,
+        secretManager: BitwardenSecretManagerRepository?,
+    ): String? {
+        if (value == null) return null
+        return BwsMarker.resolve(value) { resolveSecret(secretManager, it) }
+    }
+
     fun flattenAndResolve(
         backendConfig: Map<String, Any>,
         secretManager: BitwardenSecretManagerRepository?,

--- a/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraConfig.kt
+++ b/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/conf/KinfraConfig.kt
@@ -44,6 +44,17 @@ interface TerraformSettings {
         get() = emptyMap()
     val generateOutputDir: String?
         get() = null
+    /**
+     * サブプロジェクトの変更検出（[net.kigawa.kinfra.model.execution.SubProjectChangeFilter]）が
+     * ハッシュキャッシュの読み書きに使うR2バケット名/エンドポイント。
+     * これらは各モジュールの`.tf`ファイル側backendブロックに既にハードコードされていることが多く、
+     * `backendConfig`（-backend-config引数）に含めるとterraform initが二重定義エラーになるため、
+     * 意図的に別フィールドとして分離している。値は[BwsMarker]でラップされ得る。
+     */
+    val r2Bucket: String?
+        get() = null
+    val r2Endpoint: String?
+        get() = null
 }
 
 interface BitwardenSettings {

--- a/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/execution/SubProjectChangeFilter.kt
+++ b/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/execution/SubProjectChangeFilter.kt
@@ -43,12 +43,18 @@ interface SubProjectChangeFilter {
 }
 
 /**
- * 解決済み（bws()マーカー解決済み）backendConfigから[SubProjectChangeFilter]を組み立てる。
+ * 解決済み（bws()マーカー解決済み）backendConfig/r2Bucket/r2Endpointから[SubProjectChangeFilter]を組み立てる。
  * 実装はkinfra-infra層にあり、DIコンテナで生成されてaction層に注入される。
+ *
+ * r2Bucket/r2EndpointがbackendConfigと別引数なのは、多くの利用側で各モジュールの`.tf`ファイルに
+ * 既にbucket/endpointがハードコードされており、`-backend-config`として同じキーを渡すと
+ * terraform initが二重定義エラーになるため（[net.kigawa.kinfra.model.conf.TerraformSettings.r2Bucket]参照）。
  */
 interface SubProjectChangeFilterFactory {
     fun create(
         backendConfig: Map<String, String>,
+        r2Bucket: String?,
+        r2Endpoint: String?,
         parentProjectName: String,
     ): SubProjectChangeFilter
 }

--- a/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/execution/SubProjectExecutor.kt
+++ b/kinfra-api/src/main/kotlin/net/kigawa/kinfra/model/execution/SubProjectExecutor.kt
@@ -49,6 +49,22 @@ class SubProjectExecutor(
     fun resolveSubProjectDir(subProject: SubProject): File = loginRepo.repoPath.resolve(subProject.path).toFile()
 
     /**
+     * 変更検出（[SubProjectChangeFilter]）のハッシュキャッシュ用R2バケット名/エンドポイントを取得する
+     * （親プロジェクト設定のみ。値は`bws()`マーカーを含み得るため未解決のまま返す）
+     *
+     * @return (r2Bucket, r2Endpoint)のペア。設定が存在しない場合はnull同士のペア
+     */
+    fun getR2Config(): Pair<String?, String?> {
+        val parentConfigPath = loginRepo.kinfraBaseConfigPath().toString()
+        if (!configRepository.kinfraParentConfigExists(parentConfigPath)) {
+            return null to null
+        }
+
+        val terraform = configRepository.loadKinfraParentConfig(parentConfigPath)?.terraform
+        return terraform?.r2Bucket to terraform?.r2Endpoint
+    }
+
+    /**
      * 親プロジェクトのbackendConfigを取得
      *
      * @return backendConfig。設定が存在しない場合は空のMap

--- a/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/KinfraConfigScheme.kt
+++ b/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/KinfraConfigScheme.kt
@@ -86,6 +86,8 @@ data class TerraformSettingsScheme(
     @Serializable(with = BackendConfigSerializer::class)
     override val backendConfig: Map<String, String> = emptyMap(),
     override val generateOutputDir: String? = null,
+    override val r2Bucket: String? = null,
+    override val r2Endpoint: String? = null,
 ) : TerraformSettings {
     companion object {
         fun from(settings: TerraformSettings): TerraformSettingsScheme {
@@ -111,6 +113,8 @@ data class TerraformSettingsScheme(
                     },
                 backendConfig = settings.backendConfig,
                 generateOutputDir = settings.generateOutputDir,
+                r2Bucket = settings.r2Bucket,
+                r2Endpoint = settings.r2Endpoint,
             )
         }
     }

--- a/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/script/ConfigBuilders.kt
+++ b/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/script/ConfigBuilders.kt
@@ -16,6 +16,15 @@ class TerraformConfigBuilder {
     var version: String = ""
     var workingDirectory: String = "."
     var generateOutputDir: String? = null
+
+    /**
+     * サブプロジェクト変更検出のハッシュキャッシュ用R2バケット名/エンドポイント。
+     * 各モジュールの`.tf`ファイルのbackendブロックに既にbucket/endpointがハードコードされている場合、
+     * backendConfig{}に同じキーを含めるとterraform initが二重定義エラーになるため、
+     * ここでは意図的にbackendConfigとは別のトップレベルフィールドとして扱う。
+     */
+    var r2Bucket: String? = null
+    var r2Endpoint: String? = null
     private val backendConfigMap = mutableMapOf<String, String>()
     private val variableMappingsList = mutableListOf<TerraformVariableMappingScheme>()
     private val outputMappingsList = mutableListOf<TerraformOutputMappingScheme>()
@@ -46,6 +55,8 @@ class TerraformConfigBuilder {
             outputMappings = outputMappingsList.toList(),
             backendConfig = backendConfigMap.toMap(),
             generateOutputDir = generateOutputDir,
+            r2Bucket = r2Bucket,
+            r2Endpoint = r2Endpoint,
         )
 }
 

--- a/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/script/ConfigKtsWriter.kt
+++ b/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/config/script/ConfigKtsWriter.kt
@@ -95,6 +95,8 @@ private fun renderTerraformBlock(tf: TerraformSettingsScheme?): String? {
         if (tf.version.isNotEmpty()) appendLine("    version = ${quoted(tf.version)}")
         appendLine("    workingDirectory = ${quoted(tf.workingDirectory)}")
         tf.generateOutputDir?.let { appendLine("    generateOutputDir = ${quoted(it)}") }
+        tf.r2Bucket?.let { appendLine("    r2Bucket = ${renderBackendConfigValue(it)}") }
+        tf.r2Endpoint?.let { appendLine("    r2Endpoint = ${renderBackendConfigValue(it)}") }
 
         if (tf.backendConfig.isNotEmpty()) {
             appendLine("    backendConfig {")

--- a/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/r2/R2SubProjectChangeFilter.kt
+++ b/kinfra-infra/src/main/kotlin/net/kigawa/kinfra/infra/r2/R2SubProjectChangeFilter.kt
@@ -37,18 +37,18 @@ class R2SubProjectChangeFilter(
 class R2SubProjectChangeFilterFactory : SubProjectChangeFilterFactory {
     override fun create(
         backendConfig: Map<String, String>,
+        r2Bucket: String?,
+        r2Endpoint: String?,
         parentProjectName: String,
     ): SubProjectChangeFilter {
-        val bucket = backendConfig["bucket"]
-        val endpoint = backendConfig["endpoint"]
         val accessKey = backendConfig["access_key"]
         val secretKey = backendConfig["secret_key"]
 
-        if (bucket == null || endpoint == null || accessKey == null || secretKey == null) {
+        if (r2Bucket == null || r2Endpoint == null || accessKey == null || secretKey == null) {
             return SubProjectChangeFilter.NOOP
         }
 
-        val r2Client = R2Client(endpoint, accessKey, secretKey)
-        return R2SubProjectChangeFilter(SubProjectHashStore(r2Client, bucket, parentProjectName))
+        val r2Client = R2Client(r2Endpoint, accessKey, secretKey)
+        return R2SubProjectChangeFilter(SubProjectHashStore(r2Client, r2Bucket, parentProjectName))
     }
 }

--- a/kinfra-infra/src/test/kotlin/net/kigawa/kinfra/infra/config/script/ConfigKtsWriterTest.kt
+++ b/kinfra-infra/src/test/kotlin/net/kigawa/kinfra/infra/config/script/ConfigKtsWriterTest.kt
@@ -20,13 +20,13 @@ class ConfigKtsWriterTest {
                         workingDirectory = ".",
                         backendConfig =
                             mapOf(
-                                "bucket" to "kinfra",
                                 "key" to "kinfra.tfstate",
                                 "region" to "auto",
-                                "endpoint" to BwsMarker.wrap("r2-api"),
                                 "access_key" to BwsMarker.wrap("r2-access"),
                                 "secret_key" to BwsMarker.wrap("r2-secret"),
                             ),
+                        r2Bucket = "kinfra",
+                        r2Endpoint = BwsMarker.wrap("r2-api"),
                     ),
                 subProjects =
                     listOf(

--- a/kinfra-infra/src/test/kotlin/net/kigawa/kinfra/infra/r2/SubProjectChangeFilterTest.kt
+++ b/kinfra-infra/src/test/kotlin/net/kigawa/kinfra/infra/r2/SubProjectChangeFilterTest.kt
@@ -130,7 +130,13 @@ class SubProjectChangeFilterTest {
 
     @Test
     fun factoryFailsOpenWhenCredentialsMissing() {
-        val filter = R2SubProjectChangeFilterFactory().create(mapOf("bucket" to "infra"), "hardware")
+        val filter =
+            R2SubProjectChangeFilterFactory().create(
+                backendConfig = emptyMap(),
+                r2Bucket = "infra",
+                r2Endpoint = null,
+                parentProjectName = "hardware",
+            )
 
         runBlocking {
             val dir = tempSubProjectDir("resource \"a\" {}")
@@ -149,13 +155,14 @@ class SubProjectChangeFilterTest {
         // 返ってくることだけを確認する
         val filter =
             R2SubProjectChangeFilterFactory().create(
-                mapOf(
-                    "bucket" to "infra",
-                    "endpoint" to "https://example.r2.cloudflarestorage.com",
-                    "access_key" to "ak",
-                    "secret_key" to "sk",
-                ),
-                "hardware",
+                backendConfig =
+                    mapOf(
+                        "access_key" to "ak",
+                        "secret_key" to "sk",
+                    ),
+                r2Bucket = "infra",
+                r2Endpoint = "https://example.r2.cloudflarestorage.com",
+                parentProjectName = "hardware",
             )
 
         assertTrue(filter is R2SubProjectChangeFilter)


### PR DESCRIPTION
## Summary
PR #349（変更のあったサブプロジェクトだけをplan/apply/deployで処理するR2ハッシュベースの変更検出）のフォローアップ。

マージ後に実際のkigawa-net/infraの`kinfra-parent.kts`を確認したところ、`bucket`/`endpoint`は各Terraformモジュールの`.tf`ファイルの`backend "s3" {}`ブロックに既にハードコードされており、`backendConfig{}`経由で同じキーを`-backend-config`引数として渡すとterraform initが二重定義エラーになるため、意図的に省略されていた。一方、変更検出フィルタ（`R2SubProjectChangeFilterFactory`）は`backendConfig["bucket"]`/`["endpoint"]`に依存していたため、実運用では常にfail-open（変更検出が効かず全件処理）になってしまうことが判明した。

## Changes
- `terraform { }`ブロックに`backendConfig`とは独立した`r2Bucket`/`r2Endpoint`フィールドを新設（`TerraformSettings`インターフェース、`TerraformSettingsScheme`、DSLビルダー、`.kts`ライターの全レイヤーに追加）
- `SubProjectChangeFilterFactory.create()`のシグネチャに`r2Bucket`/`r2Endpoint`パラメータを追加し、`backendConfig`からは`access_key`/`secret_key`のみ取得するよう変更
- `BackendConfigResolver`に単一値の`bws()`マーカー解決用ヘルパー`resolveValue()`を追加
- `PlanAction`/`ApplyAction`/`DeployAction`/`DeployActionWithSDK`の`createChangeFilter()`を新シグネチャに対応

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` が全モジュールで成功
- [x] `./gradlew test` が全モジュールで成功（`ConfigKtsWriterTest`のラウンドトリップテストにr2Bucket/r2Endpointを追加、`SubProjectChangeFilterTest`を新シグネチャに更新）
- [ ] マージ後、別PRで`kigawa-net/infra`の`hardware/kinfra-parent.kts`/`platform/kinfra-parent.kts`に実際の`r2Bucket`/`r2Endpoint`値を設定し、実地で変更検出が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)