### PR TITLE
fix: terraform plan/applyに-backend-configを渡していたバグを修正

### DIFF
--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/ApplyAction.kt
@@ -132,10 +132,9 @@ class ApplyAction(
             return initExitCode
         }
 
+        // -backend-configはterraform init専用のフラグでapplyでは受け付けられない
+        // (backendは直前のinitで既に設定済み)
         val applyArgs = mutableListOf("terraform", "apply", "-input=false", "-auto-approve")
-        backendConfig.forEach { (key, value) ->
-            applyArgs.add("-backend-config=$key=$value")
-        }
 
         val process =
             ProcessBuilder(applyArgs)

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/CurrentApplyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/CurrentApplyAction.kt
@@ -93,13 +93,9 @@ class CurrentApplyAction(
                 args + "-auto-approve"
             }
 
+        // -backend-configはterraform init専用のフラグでapplyでは受け付けられない
+        // (backendは直前のinitで既に設定済み)
         val applyArgs = mutableListOf("terraform", "apply", "-input=false")
-        flattenedConfig.forEach { (key, value) ->
-            applyArgs.add("-backend-config=$key=$value")
-        }
-        if (backendTfvarsFile.exists()) {
-            applyArgs.add("-backend-config=backend.tfvars")
-        }
         applyArgs.addAll(argsWithAutoApprove)
 
         val process =

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/CurrentPlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/CurrentPlanAction.kt
@@ -108,21 +108,9 @@ class CurrentPlanAction(
             return initExitCode
         }
 
+        // -backend-configはterraform init専用のフラグでplanでは受け付けられない
+        // (backendは直前のinitで既に設定済み)
         val planArgs = mutableListOf("terraform", "plan", "-input=false")
-
-        // backendConfigから-backend-configオプションを追加
-        backendConfig?.let { config ->
-            val flattenedConfig = flattenBackendConfig(config)
-            flattenedConfig.forEach { (key, value) ->
-                planArgs.add("-backend-config=$key=$value")
-            }
-        }
-
-        // backend.tfvarsが存在する場合も追加
-        if (backendTfvarsFile.exists()) {
-            planArgs.add("-backend-config=backend.tfvars")
-        }
-
         planArgs.addAll(args)
 
         val process =

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/PlanAction.kt
@@ -103,10 +103,9 @@ class PlanAction(
                             return@executeInSubProjects initExitCode
                         }
 
+                        // -backend-configはterraform init専用のフラグでplanでは受け付けられない
+                        // (backendは直前のinitで既に設定済み)
                         val planArgs = mutableListOf("terraform", "plan", "-input=false")
-                        backendConfig.forEach { (key, value) ->
-                            planArgs.add("-backend-config=$key=$value")
-                        }
 
                         val process =
                             ProcessBuilder(planArgs)

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubApplyAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubApplyAction.kt
@@ -97,13 +97,9 @@ class SubApplyAction(
                         additionalArgs + "-auto-approve"
                     }
 
+                // -backend-configはterraform init専用のフラグでapplyでは受け付けられない
+                // (backendは直前のinitで既に設定済み)
                 val applyArgs = mutableListOf("terraform", "apply", "-input=false")
-                flattenedBackendConfig.forEach { (key, value) ->
-                    applyArgs.add("-backend-config=$key=$value")
-                }
-                if (backendTfvarsFile.exists()) {
-                    applyArgs.add("-backend-config=backend.tfvars")
-                }
                 applyArgs.addAll(argsWithAutoApprove)
 
                 // サブプロジェクトディレクトリでterraform applyを実行

--- a/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubPlanAction.kt
+++ b/action/src/main/kotlin/net/kigawa/kinfra/action/actions/SubPlanAction.kt
@@ -83,13 +83,9 @@ class SubPlanAction(
                     return@executeInSubProjects initExitCode
                 }
 
+                // -backend-configはterraform init専用のフラグでplanでは受け付けられない
+                // (backendは直前のinitで既に設定済み)
                 val planArgs = mutableListOf("terraform", "plan", "-input=false")
-                flattenedBackendConfig.forEach { (key, value) ->
-                    planArgs.add("-backend-config=$key=$value")
-                }
-                if (backendTfvarsFile.exists()) {
-                    planArgs.add("-backend-config=backend.tfvars")
-                }
 
                 // サブプロジェクトディレクトリでterraform planを実行
                 val process =


### PR DESCRIPTION
## Summary
kigawa-net/infraでのR2変更検出フィルタ実地検証（workflow_dispatch実行）中に、`hardware/k8s1`サブプロジェクトの`kinfra sub plan`相当の処理が以下のエラーで失敗することが判明した:

```
Error: Failed to parse command-line flags
flag provided but not defined: -backend-config

Error: Too many command line arguments
To specify a working directory for the plan, use the global -chdir flag.
```

`-backend-config`は`terraform init`専用のフラグで、`terraform plan`/`terraform apply`には存在しない。ところが`PlanAction`/`ApplyAction`/`CurrentPlanAction`/`CurrentApplyAction`/`SubPlanAction`/`SubApplyAction`の全てで、init用に組み立てたbackendConfig引数を誤ってplan/apply側のコマンドにもそのまま付与していた（backendは直前の`init`で既に設定済みなので不要）。

## Changes
- 上記6ファイルのplan/apply引数組み立てから`-backend-config=...`の付与処理を削除（`terraform init`側は変更なし）

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` が全モジュールで成功
- [x] `./gradlew test` が全モジュールで成功
- [ ] マージ後、`kigawa-net/infra`の`terraform-kinfra.yml`をworkflow_dispatchで再実行し、hardware全サブプロジェクトのplanが完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)