### PR TITLE
fix: auto-tag.ymlのJDKを21から24に更新

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -57,11 +57,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         if: steps.check_release.outputs.exists == 'false'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Setup Gradle


### PR DESCRIPTION
## Summary
`release/0.0.57`(#353)のマージ後、`auto-tag.yml`がテスト実行段階で以下のエラーで失敗することを確認した:

```
net/kigawa/kinfra/model/conf/BackendConfigResolverTest has been compiled by a more recent
version of the Java Runtime (class file version 68.0), this version of the Java Runtime
only recognizes class file versions up to 65.0
```

原因: プロジェクトのKotlin/Javaコンパイルターゲットは(`eclipse-temurin:25`使用時のKotlinの
フォールバックにより)JVM 24になっているが、`auto-tag.yml`は`JDK 21`でテストを実行していた。
手動リリース用の`release.yml`は既に`java-version: '24'`で正しく設定されている。

`release/0.0.56`が2025-10-27に2回マージされたにも関わらず対応するタグ/GitHub Releaseが
一度も作成されていなかったのは、このJDKバージョン不整合が原因だったと考えられる(9ヶ月間、
リリースパイプラインが壊れていた)。

## Changes
- `.github/workflows/auto-tag.yml`: `Set up JDK 21` → `Set up JDK 24`

## Test plan
- [ ] マージ後、次にrelease/x.y.zブランチがmainにマージされた際に`auto-tag.yml`のテストが成功し、タグ/Releaseが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)