### PR TITLE
fix: kigawa-net-app-token action.ymlのsecrets式エラーを修正

### DIFF
--- a/.github/actions/kigawa-net-app-token/action.yml
+++ b/.github/actions/kigawa-net-app-token/action.yml
@@ -9,7 +9,7 @@ inputs:
   ci-token:
     description: >-
       Shared secret for admin-panel's CI token endpoint. Pass via
-      ${{ secrets.ADMIN_PANEL_CI_TOKEN }}.
+      secrets.ADMIN_PANEL_CI_TOKEN from the calling workflow.
     required: true
   owner:
     description: 'GitHub org/user to scope the token to.'


### PR DESCRIPTION
## Summary
admin-panelの`build-push.yml`から`kigawa-net/kinfra/.github/actions/kigawa-net-app-token@main`を使おうとしたところ、以下のエラーでアクション自体のロードに失敗した:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.ADMIN_PANEL_CI_TOKEN
Failed to load kigawa-net/kinfra/main/.github/actions/kigawa-net-app-token/action.yml
```

原因: `ci-token`入力の`description`フィールドに、ドキュメント目的で `${{ secrets.ADMIN_PANEL_CI_TOKEN }}` という記法をそのまま書いていた。GitHub Actionsはファイル中の`${{ }}`をどこにあっても実際のテンプレート式として評価しようとするが、composite actionのマニフェスト自体を評価する時点では`secrets`コンテキストが使えないため、単なる説明文のつもりで書いた式がパースエラーになっていた。

## Changes
- `.github/actions/kigawa-net-app-token/action.yml`: descriptionの`${{ }}`記法を除去し、プレーンテキストに変更

## Test plan
- [ ] マージ後、admin-panelの`build-push.yml`を再実行してこのcomposite actionが正しくロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)