### PR TITLE
feat: kigawa-net-app-tokenをOIDCベースの認証に変更

### DIFF
--- a/.github/actions/kigawa-net-app-token/README.md
+++ b/.github/actions/kigawa-net-app-token/README.md
@@ -4,11 +4,14 @@ Reusable composite action that mints a short-lived installation token for the
 `kigawa-net` GitHub App (app_id `4316503`, `contents:write` on all org repos),
 so workflows can stop relying on the shared long-lived `GIT_TOKEN` PAT.
 
-**Flow: custom action (this) -> admin-panel -> GitHub App.** The App's
-private key lives only on the admin-panel server (kigawa-net/admin-panel#41,
-kigawa-net/admin-panel#46); this action never sees it. It authenticates to
-admin-panel's broker endpoint (`POST /api/github-app/ci-token`) with a shared
-CI token instead.
+**Flow: custom action (this) -> admin-panel (verifies OIDC) -> GitHub App.**
+The App's private key lives only on the admin-panel server
+(kigawa-net/admin-panel#41, kigawa-net/admin-panel#46). This action proves
+its identity to admin-panel's broker endpoint (`POST /api/github-app/ci-token`)
+with its own GitHub Actions OIDC token — no shared secret is involved on
+either side. admin-panel verifies the token against GitHub's own published
+keys and authorizes the request based on the token's `repository` claim (see
+`CiTokenPolicy.kt` in admin-panel), not on anything the caller can spoof.
 
 ## One-time org setup (manual, do once)
 
@@ -17,35 +20,34 @@ CI token instead.
    `admin-panel-github-app` k8s Secret (`private-key` key), via the
    `BitwardenSecret` CRD in `k8s/base/github-app-bws.yaml` — see
    kigawa-net/admin-panel#46.
-2. The shared CI token is generated and wired up entirely by Terraform
-   (`platform/admin-panel` in kigawa-net/infra#35): it's stored in Bitwarden
-   as the `ci-token` key of the same `admin-panel-github-app` k8s Secret,
-   *and* registered directly as the organization-level GitHub Actions
-   secret `ADMIN_PANEL_CI_TOKEN` (visible only to admin-panel and kinfra) —
-   no manual `gh secret set` needed. The only remaining manual step is
-   minting the `admin:org`-scoped GitHub PAT that module's `github` provider
-   authenticates with; see kigawa-net/infra#35 for details.
+2. Add an entry for the calling repository to admin-panel's
+   `CiTokenPolicy.kt` (allowed target owner/repositories/permissions) and
+   merge that PR — this is the only "registration" a new caller needs.
+
+No shared secret needs to be generated, stored, or rotated for CI's use of
+this action.
 
 ## Usage
 
-```yaml
-- name: Get GitHub App token
-  id: app-token
-  uses: kigawa-net/kinfra/.github/actions/kigawa-net-app-token@main
-  with:
-    ci-token: ${{ secrets.ADMIN_PANEL_CI_TOKEN }}
-
-- name: Checkout
-  uses: actions/checkout@v4
-  with:
-    token: ${{ steps.app-token.outputs.token }}
-
-# ... later, `git push` in this checkout authenticates as the App automatically.
-```
-
-To scope the token to specific repos or a permission subset:
+The calling job must request an OIDC token:
 
 ```yaml
-    repositories: kigawa-net-k8s
-    permissions: '{"contents":"write"}'
+permissions:
+  id-token: write
+
+steps:
+  - name: Get GitHub App token
+    id: app-token
+    uses: kigawa-net/kinfra/.github/actions/kigawa-net-app-token@main
+    with:
+      owner: kigawa-net
+      repositories: kigawa-net-k8s
+      permissions: '{"contents":"write"}'
+
+  - name: Checkout
+    uses: actions/checkout@v4
+    with:
+      token: ${{ steps.app-token.outputs.token }}
+
+  # ... later, `git push` in this checkout authenticates as the App automatically.
 ```

--- a/.github/actions/kigawa-net-app-token/action.yml
+++ b/.github/actions/kigawa-net-app-token/action.yml
@@ -2,15 +2,10 @@ name: 'kigawa-net App Token'
 description: >-
   Mints a short-lived installation access token for the "kigawa-net" GitHub App
   (app_id 4316503, contents:write) by calling admin-panel's GitHub App broker
-  endpoint. The App's private key lives only on admin-panel; this action (and
-  the CI workflows using it) only ever handles a shared CI token, never the
-  key itself. Flow: custom action -> admin-panel -> GitHub App.
+  endpoint. The App's private key lives only on admin-panel; this action proves
+  its identity with its own GitHub Actions OIDC token instead of a shared
+  secret. Flow: custom action -> admin-panel (verifies OIDC) -> GitHub App.
 inputs:
-  ci-token:
-    description: >-
-      Shared secret for admin-panel's CI token endpoint. Pass via
-      ${{ secrets.ADMIN_PANEL_CI_TOKEN }}.
-    required: true
   owner:
     description: 'GitHub org/user to scope the token to.'
     required: false
@@ -29,6 +24,12 @@ inputs:
     description: 'Base URL of the admin-panel API.'
     required: false
     default: 'https://admin.kigawa.net/api'
+  oidc-audience:
+    description: >-
+      Audience to request for this action's own OIDC token. Must match
+      admin-panel's configured ADMIN_PANEL_ACTIONS_AUDIENCE.
+    required: false
+    default: 'https://admin.kigawa.net'
 outputs:
   token:
     description: 'Short-lived installation access token'
@@ -40,6 +41,22 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+          echo "::error::No OIDC request token/URL available. Add 'permissions: id-token: write' to the calling job."
+          exit 1
+        fi
+
+        oidc_token=$(curl -sS -f -G \
+          -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          --data-urlencode "audience=${{ inputs.oidc-audience }}" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
+
+        if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+          echo "::error::failed to mint an OIDC token"
+          exit 1
+        fi
+        echo "::add-mask::$oidc_token"
 
         repos_json="null"
         if [ -n "${{ inputs.repositories }}" ]; then
@@ -58,7 +75,7 @@ runs:
           '{owner: $owner, repositories: $repositories, permissions: $permissions}')
 
         response=$(curl -sS -f -X POST "${{ inputs.admin-panel-url }}/github-app/ci-token" \
-          -H "X-CI-Token: ${{ inputs.ci-token }}" \
+          -H "Authorization: Bearer $oidc_token" \
           -H "Content-Type: application/json" \
           -d "$body")
 


### PR DESCRIPTION
## Summary
`ci-token`(共有シークレット)入力を廃止し、呼び出し元ワークフロー自身のGitHub Actions OIDCトークンを`ACTIONS_ID_TOKEN_REQUEST_URL`/`ACTIONS_ID_TOKEN_REQUEST_TOKEN`経由で取得し、admin-panelの`/api/github-app/ci-token`に`Authorization: Bearer`で送るよう変更する。

- 対応先: [kigawa-net/admin-panel#66](https://github.com/kigawa-net/admin-panel/pull/66)(OIDC検証 + 呼び出し元リポジトリごとの許可リスト)
- 呼び出し元ワークフローは`permissions: id-token: write`が必須になる(README更新済み)。
- `ADMIN_PANEL_CI_TOKEN` secretはもう不要(Bitwarden/Terraformモジュール側の後片付けは別途)。

## 前提
- admin-panel#66がマージ・デプロイされていること。
- 新しい呼び出し元リポジトリは、admin-panelの`CiTokenPolicy.kt`に許可リストを追加する必要がある。

## Test plan
- [x] action.ymlのYAML構文チェック済み
- [ ] admin-panel#66デプロイ後、実際のワークフローからOIDC経由でトークン取得できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)