### PR TITLE
fix: kigawa-net-app-tokenのシェル引用符崩れ(JSON permissions)を修正

### DIFF
--- a/.github/actions/kigawa-net-app-token/action.yml
+++ b/.github/actions/kigawa-net-app-token/action.yml
@@ -39,6 +39,17 @@ runs:
   steps:
     - id: request-token
       shell: bash
+      env:
+        # Routed through env: rather than interpolated directly into the script text below,
+        # since a raw ${{ inputs.x }} substitution breaks (or is injectable) whenever the value
+        # itself contains shell-meaningful characters — e.g. `permissions` is a JSON object full
+        # of double quotes, which corrupted the double-quoted `perms_json="${{ inputs.permissions }}"`
+        # form this used to take.
+        INPUT_OWNER: ${{ inputs.owner }}
+        INPUT_REPOSITORIES: ${{ inputs.repositories }}
+        INPUT_PERMISSIONS: ${{ inputs.permissions }}
+        INPUT_ADMIN_PANEL_URL: ${{ inputs.admin-panel-url }}
+        INPUT_OIDC_AUDIENCE: ${{ inputs.oidc-audience }}
       run: |
         set -euo pipefail
 
@@ -49,7 +60,7 @@ runs:
 
         oidc_token=$(curl -sS -f -G \
           -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          --data-urlencode "audience=${{ inputs.oidc-audience }}" \
+          --data-urlencode "audience=$INPUT_OIDC_AUDIENCE" \
           "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
 
         if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
@@ -59,22 +70,22 @@ runs:
         echo "::add-mask::$oidc_token"
 
         repos_json="null"
-        if [ -n "${{ inputs.repositories }}" ]; then
-          repos_json=$(printf '%s' "${{ inputs.repositories }}" | tr ',\n' '\n' | sed '/^[[:space:]]*$/d' | jq -R . | jq -s .)
+        if [ -n "$INPUT_REPOSITORIES" ]; then
+          repos_json=$(printf '%s' "$INPUT_REPOSITORIES" | tr ',\n' '\n' | sed '/^[[:space:]]*$/d' | jq -R . | jq -s .)
         fi
 
-        perms_json="${{ inputs.permissions }}"
+        perms_json="$INPUT_PERMISSIONS"
         if [ -z "$perms_json" ]; then
           perms_json="null"
         fi
 
         body=$(jq -n \
-          --arg owner "${{ inputs.owner }}" \
+          --arg owner "$INPUT_OWNER" \
           --argjson repositories "$repos_json" \
           --argjson permissions "$perms_json" \
           '{owner: $owner, repositories: $repositories, permissions: $permissions}')
 
-        response=$(curl -sS -f -X POST "${{ inputs.admin-panel-url }}/github-app/ci-token" \
+        response=$(curl -sS -f -X POST "$INPUT_ADMIN_PANEL_URL/github-app/ci-token" \
           -H "Authorization: Bearer $oidc_token" \
           -H "Content-Type: application/json" \
           -d "$body")


### PR DESCRIPTION
## Summary
`OneServerMC/RpgCore`のdevelopへのpushで実際に再現した障害の修正:

```
jq: invalid JSON text passed to --argjson
```

`perms_json="${{ inputs.permissions }}"` のように、JSON値(二重引用符を含む)を bashの二重引用符文字列に直接テキスト埋め込みしていたため、`permissions: '{"contents":"write"}'` のような実際の値を渡すと引用符が壊れ、`perms_json={contents:write}`(クォート無し、不正なJSON)になっていた。

全input(`owner`/`repositories`/`permissions`/`admin-panel-url`/`oidc-audience`)を`env:`経由の環境変数に変更し、スクリプト内では`$INPUT_*`として参照するよう修正。同じクラスの問題(シェルメタ文字を含む値での崩れ・インジェクション)を全input分まとめて解消。

## Test plan
- [x] action.ymlのYAML構文チェック済み
- [x] 修正後のシェルロジックをローカルで実行し、`{"contents":"write"}`を含む実際の値で正しいJSONが組み立てられることを確認済み
- [ ] マージ後、実際のワークフローで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)